### PR TITLE
Fixed issues exposed by a third party project

### DIFF
--- a/includeorder.py
+++ b/includeorder.py
@@ -38,7 +38,7 @@ class IncludeOrder(Task):
                         "cstdbool"]
 
         # All other headers matching this pattern are C system headers
-        self.c_sys_regex = re.compile("<.*\.h>")
+        self.c_sys_regex = re.compile("<[a-z].*\.h>")
 
         self.header_regex = re.compile("(?P<header>"
                                          "(?P<open_bracket><|\")"

--- a/licenseupdate.py
+++ b/licenseupdate.py
@@ -33,7 +33,7 @@ class LicenseUpdate(Task):
         else:
             file_parts = ["", lines.lstrip()]
 
-        year_regex = re.compile("Copyright \(c\) [\w\s]+\s+(20..)")
+        year_regex = re.compile("Copyright \(c\) [\w\s,\.]+\s+(20..)")
         year = ""
         modify_copyright = False
         for line in file_parts[0].split(os.linesep):

--- a/lint.py
+++ b/lint.py
@@ -31,11 +31,13 @@ class Lint(Task):
         sys.argv = ["cpplint.py", "--filter="
                     "-build/c++11,"
                     "-build/include,"
+                    "-build/include_order,"  # includeorder.py handles ordering
                     "-build/include_subdir,"
                     "-build/namespaces,"
                     "-readability/todo,"
                     "-runtime/references,"
-                    "-runtime/string",
+                    "-runtime/string,"
+                    "-whitespace/indent",  # clangformat.py handles indentation
                     "--extensions=" + \
                         ",".join(self.get_config("cppHeaderExtensions") + \
                                  self.get_config("cppSrcExtensions")),

--- a/unittest.py
+++ b/unittest.py
@@ -116,6 +116,15 @@ def test_includeorder():
         "#include \"MyHeader.h\"" + os.linesep + \
         "#include \"Test.inc\"" + os.linesep, True, True))
 
+    # Check "other header" isn't identified as C system include
+    inputs.append(("./Test.h",
+        "#include <OtherHeader.h>" + os.linesep + \
+        "#include <sys/time.h>" + os.linesep))
+    outputs.append((
+        "#include <sys/time.h>" + os.linesep + \
+        os.linesep + \
+        "#include <OtherHeader.h>" + os.linesep, True, True))
+
     # Check newline is added between last header and code after it
     inputs.append(("./Test.cpp",
         "#include \"MyFile.h\"" + os.linesep + \


### PR DESCRIPTION
In includeorder.py, the C system include check was made more specific.
In licenseupdate.py, company names can now have commas and periods in them.
In lint.py, the -whitespace/indent flag was added since clangformat.py already handles indentation, and third party projects might not format their source according to Google's style guide.