### PR TITLE
Make format.py compatible with Python 3.4

### DIFF
--- a/format.py
+++ b/format.py
@@ -18,8 +18,9 @@ from whitespace import Whitespace
 
 # Check that the current directory is part of a Git repository
 def in_git_repo(directory):
-    ret = subprocess.run(["git", "rev-parse"], stderr = subprocess.DEVNULL)
-    return ret.returncode == 0
+    cmd = ["git", "rev-parse"]
+    returncode = subprocess.call(cmd, stderr = subprocess.DEVNULL)
+    return returncode == 0
 
 def proc_func(procnum, work, is_verbose, print_lock, ret_dict):
     # IncludeOrder is run after Stdlib so any C std headers changed to C++ or


### PR DESCRIPTION
There was only one place which used a feature specific to Python 3.5, and MSYS2 provides Python 3.4, so this patch restores compatibility with Python 3.4.