### PR TITLE
format.py file referencing is now more generic

### DIFF
--- a/format.py
+++ b/format.py
@@ -73,12 +73,24 @@ def main():
         print("Error: not invoked within a Git repository", file = sys.stderr)
         sys.exit(1)
 
-    # Handle running in either the root or styleguide directories
+    # All file paths are relative to Git repo root directory, so find the root.
+    # We can assume the ".git" exists because we already checked we are in a Git
+    # repo. Checking "len(directory) > 0" isn't necessary.
     config_path = ""
-    if os.getcwd().rpartition(os.sep)[2] == "styleguide":
-        config_path = ".."
-    else:
-        config_path = "."
+    git_dir_found = False
+    directory = os.getcwd()
+    while not git_dir_found:
+        git_location = directory + os.sep + ".git"
+        if os.path.isdir(git_location):
+            git_dir_found = True
+            if config_path == "":
+                config_path = "."
+        else:
+            directory = directory[:directory.rfind(os.sep)]
+            if config_path == "":
+                config_path += ".."
+            else:
+                config_path += os.sep + ".."
 
     # Delete temporary files from previous incomplete run
     files = [os.path.join(dp, f) for dp, dn, fn in
@@ -119,7 +131,7 @@ def main():
         sys.exit(0)
 
     # Parse command-line arguments
-    parser = argparse.ArgumentParser(description = "Runs all formatting tasks on the code base. This should be invoked from either the styleguide directory or the root directory of the project.")
+    parser = argparse.ArgumentParser(description = "Runs all formatting tasks on the code base. This should be invoked from a directory within the project.")
     parser.add_argument("-v", dest = "verbose", action = "store_true",
                         help = "enable output verbosity")
     parser.add_argument("-j", dest = "jobs", type = int,

--- a/licenseupdate.py
+++ b/licenseupdate.py
@@ -99,5 +99,6 @@ class LicenseUpdate(Task):
                 with open(template_location, "r") as template_file:
                     config_found = True
                     return template_file.read().splitlines()
-            directory = directory[:directory.rfind(os.sep)]
+            else:
+                directory = directory[:directory.rfind(os.sep)]
         return None


### PR DESCRIPTION
Since format.py used to exist within a "styleguide" directory in WPILib, it was hardcoded to check whether it was called from within that directory and added "../" to file paths if so. Since this repository is called "styleguide", format.py erroneously adds "../" to all file paths when run on this repository.

This commit modifies format.py to search for the ".git" folder in the repo's root directory and references files based on its location.