### PR TITLE
Fixed how licenseupdate detects the end of a license header

### DIFF
--- a/licenseupdate.py
+++ b/licenseupdate.py
@@ -27,15 +27,22 @@ class LicenseUpdate(Task):
             sys.exit(1)
 
         # Strip newlines at top of file
-        stripped_lines = lines.lstrip()
+        stripped_lines = lines.lstrip().split(linesep)
 
         # License should be at beginning of file and followed by two newlines.
         # If a comment exists at the top of the file, treat it as the license
         # header
-        if stripped_lines.startswith("//") or stripped_lines.startswith("/*"):
-            file_parts = stripped_lines.split(linesep + linesep, 1)
+        license_end = 0
+        while stripped_lines[license_end].startswith("//") or \
+            stripped_lines[license_end].startswith("/*"):
+            license_end += 1
+
+        if license_end > 0:
+            file_parts = \
+                [linesep.join(stripped_lines[0:license_end]),
+                 linesep + linesep.join(stripped_lines[license_end:]).lstrip()]
         else:
-            file_parts = ["", lines.lstrip()]
+            file_parts = ["", linesep + lines.lstrip()]
 
         year_regex = re.compile("Copyright \(c\) [\w\s,\.]+\s+(20..)")
         year = ""
@@ -73,7 +80,7 @@ class LicenseUpdate(Task):
 
         # Copy rest of original file into new one
         if len(file_parts) > 1:
-            output += linesep + file_parts[1]
+            output += file_parts[1]
 
         return (output, lines != output, True)
 

--- a/unittest.py
+++ b/unittest.py
@@ -288,6 +288,24 @@ def test_licenseupdate():
         format(year) + os.linesep + os.linesep + file_appendix))
     outputs.append((inputs[len(inputs) - 1][1], False, True))
 
+    # File with three newlines between license and include guard
+    inputs.append((
+        "./Test.h",
+        "/*                                Company Name                                */"
+        + os.linesep +
+        "/* Copyright (c) Company Name {}. All Rights Reserved.                      */".
+        format(year) + os.linesep + os.linesep + os.linesep + file_appendix))
+    outputs.append((outputs[len(outputs) - 1][0], True, True))
+
+    # File with only one newline between license and include guard
+    inputs.append((
+        "./Test.h",
+        "/*                                Company Name                                */"
+        + os.linesep +
+        "/* Copyright (c) Company Name {}. All Rights Reserved.                      */".
+        format(year) + os.linesep + file_appendix))
+    outputs.append((outputs[len(outputs) - 1][0], True, True))
+
     return test(task, inputs, outputs)
 
 


### PR DESCRIPTION
Previously, license headers were delimited by two newlines in a row. If include guards don't have those newlines before them, they are removed from the file. License headers are now delimited by lines that don't start with a comment.