### PR TITLE
Fixed how format.py finds ".git"

### DIFF
--- a/format.py
+++ b/format.py
@@ -100,7 +100,9 @@ def main():
     directory = os.getcwd()
     while not git_dir_found:
         git_location = directory + os.sep + ".git"
-        if os.path.isdir(git_location):
+
+        # ".git" can be a directory or a file within Git submodules
+        if os.path.exists(git_location):
             git_dir_found = True
             if config_path == "":
                 config_path = "."


### PR DESCRIPTION
In most cases, it's a directory. However, Git submodules make this a file containing a Git metadata location instead. This patch allows format.py to find both.