### PR TITLE
Refactored config file helper functions into task.py

### DIFF
--- a/clangformat.py
+++ b/clangformat.py
@@ -3,15 +3,15 @@
 import subprocess
 import sys
 
-from task import Task
+import task
 
 
-class ClangFormat(Task):
+class ClangFormat(task.Task):
 
     def get_file_extensions(self):
-        return Task.get_config("cExtensions") + \
-            Task.get_config("cppHeaderExtensions") + \
-            Task.get_config("cppSrcExtensions")
+        return task.get_config("cExtensions") + \
+            task.get_config("cppHeaderExtensions") + \
+            task.get_config("cppSrcExtensions")
 
     def run(self, name, lines):
         args = ["-assume-filename=" + name, "-style=file", "-"]

--- a/format.py
+++ b/format.py
@@ -15,7 +15,7 @@ from namespace import Namespace
 from newline import Newline
 from pyformat import PyFormat
 from stdlib import Stdlib
-from task import Task
+import task
 from whitespace import Whitespace
 
 
@@ -136,7 +136,7 @@ def main():
     # Don't check for changes in or run tasks on modifiable or ignored files
     files = [
         name for name in files
-        if not Task.is_modifiable_file(name) and not Task.is_ignored_file(name)
+        if not task.is_modifiable_file(name) and not task.is_ignored_file(name)
     ]
 
     # Create list of all changed files
@@ -149,11 +149,11 @@ def main():
 
     # Emit warning if a generated file was editted
     for name in files:
-        if Task.is_generated_file(name) and name in changed_file_list:
+        if task.is_generated_file(name) and name in changed_file_list:
             print("Warning: generated file '" + name + "' modified")
 
     # Don't format generated files
-    files = [name for name in files if not Task.is_generated_file(name)]
+    files = [name for name in files if not task.is_generated_file(name)]
 
     # If there are no files left, do nothing
     if len(files) == 0:

--- a/includeorder.py
+++ b/includeorder.py
@@ -3,13 +3,13 @@
 import os
 import re
 
-from task import Task
+import task
 
 
-class IncludeOrder(Task):
+class IncludeOrder(task.Task):
 
     def __init__(self):
-        Task.__init__(self)
+        task.Task.__init__(self)
 
         self.c_std = [
             "assert.h", "complex.h", "ctype.h", "errno.h", "fenv.h", "float.h",
@@ -48,11 +48,11 @@ class IncludeOrder(Task):
                                        "(?P<postfix>.*)")
 
     def get_file_extensions(self):
-        return Task.get_config("cppHeaderExtensions") + \
-            Task.get_config("cppSrcExtensions")
+        return task.get_config("cppHeaderExtensions") + \
+            task.get_config("cppSrcExtensions")
 
     def run(self, name, lines):
-        linesep = Task.get_linesep(lines)
+        linesep = task.get_linesep(lines)
 
         self.name = name
 
@@ -74,10 +74,10 @@ class IncludeOrder(Task):
                 "includeRelated", "includeCSys", "includeCppSys",
                 "includeOtherLibs", "includeProject"
         ]:
-            if not len(Task.get_config(group)):
+            if not len(task.get_config(group)):
                 override_regexes.append(re.compile("a^"))
             else:
-                regex_str = "(" + "|".join(Task.get_config(group)) + ")"
+                regex_str = "(" + "|".join(task.get_config(group)) + ")"
 
                 # On Windows, fix forward slash for include regexes
                 if os.sep == "\\":
@@ -138,7 +138,7 @@ class IncludeOrder(Task):
                     # Is related if include has same base name as file name and
                     # file has a source extension
                     include_is_related = include_name[0] == file_name[0] and \
-                        file_name[1][1:] in Task.get_config("cppSrcExtensions")
+                        file_name[1][1:] in task.get_config("cppSrcExtensions")
 
                     if include_is_related or "NOLINT" in lines_list[line_count]:
                         includes[0].append(self.fixup_include(name, 0))

--- a/licenseupdate.py
+++ b/licenseupdate.py
@@ -5,22 +5,21 @@ import os
 import re
 import sys
 
-from task import Task
+import task
 
 
-class LicenseUpdate(Task):
+class LicenseUpdate(task.Task):
 
     def get_file_extensions(self):
-        return Task.get_config("cExtensions") + \
-            Task.get_config("cppHeaderExtensions") + \
-            Task.get_config("cppSrcExtensions") + \
-            Task.get_config("otherExtensions")
+        return task.get_config("cExtensions") + \
+            task.get_config("cppHeaderExtensions") + \
+            task.get_config("cppSrcExtensions") + \
+            task.get_config("otherExtensions")
 
     def run(self, name, lines):
-        linesep = Task.get_linesep(lines)
+        linesep = task.get_linesep(lines)
 
-        license_template = \
-            self.read_license_template(".styleguide-license", name)
+        license_template = task.read_config_file(".styleguide-license")
         if not license_template:
             print("Error: license template file '.styleguide-license' not " \
                   "found")
@@ -107,32 +106,3 @@ class LicenseUpdate(Task):
             output += file_parts[1]
 
         return (output, lines != output, True)
-
-    """Read license template from file
-
-    Checks current directory for config file. If one doesn't exist, try all
-    parent directories as well.
-
-    template_name -- name of license template file
-    file_name -- name of file currently being processed
-
-    Returns list containing license template or None if file was not found.
-    """
-
-    @staticmethod
-    def read_license_template(template_name, file_name):
-        config_found = False
-        directory = os.path.dirname(file_name)
-
-        if not directory.startswith("./"):
-            directory = "./" + directory
-
-        while not config_found and len(directory) > 0:
-            template_location = directory + os.sep + template_name
-            if os.path.isfile(template_location):
-                with open(template_location, "r") as template_file:
-                    config_found = True
-                    return template_file.read().splitlines()
-            else:
-                directory = directory[:directory.rfind(os.sep)]
-        return None

--- a/lint.py
+++ b/lint.py
@@ -13,14 +13,14 @@ import sys
 
 import cpplint
 
-from task import Task
+import task
 
 
-class Lint(Task):
+class Lint(task.Task):
 
     def get_file_extensions(self):
-        return Task.get_config("cppHeaderExtensions") + \
-            Task.get_config("cppSrcExtensions")
+        return task.get_config("cppHeaderExtensions") + \
+            task.get_config("cppSrcExtensions")
 
     def run(self, name, lines):
         # Handle running in either the root or styleguide directories
@@ -41,10 +41,10 @@ class Lint(Task):
                     "-runtime/string,"
                     "-whitespace/indent",  # clangformat.py handles indentation
                     "--extensions=" + \
-                        ",".join(self.get_config("cppHeaderExtensions") + \
-                                 self.get_config("cppSrcExtensions")),
+                        ",".join(task.get_config("cppHeaderExtensions") + \
+                                 task.get_config("cppSrcExtensions")),
                     "--headers=" + \
-                        ",".join(Task.get_config("cppHeaderExtensions")),
+                        ",".join(task.get_config("cppHeaderExtensions")),
                     "--quiet",
                     name]
 

--- a/namespace.py
+++ b/namespace.py
@@ -2,16 +2,16 @@
 
 import re
 
-from task import Task
+import task
 
 
-class Namespace(Task):
+class Namespace(task.Task):
 
     def get_file_extensions(self):
-        return Task.get_config("cppHeaderExtensions")
+        return task.get_config("cppHeaderExtensions")
 
     def run(self, name, lines):
-        linesep = Task.get_linesep(lines)
+        linesep = task.get_linesep(lines)
         format_succeeded = True
 
         # Tokenize file as brace opens, brace closes, and "using" declarations.

--- a/newline.py
+++ b/newline.py
@@ -1,12 +1,12 @@
 """This task ensures that the file has exactly one EOF newline."""
 
-from task import Task
+import task
 
 
-class Newline(Task):
+class Newline(task.Task):
 
     def run(self, name, lines):
-        linesep = Task.get_linesep(lines)
+        linesep = task.get_linesep(lines)
 
         newlines = 0
         pos = len(lines) - 1

--- a/pyformat.py
+++ b/pyformat.py
@@ -3,10 +3,10 @@
 import subprocess
 import sys
 
-from task import Task
+import task
 
 
-class PyFormat(Task):
+class PyFormat(task.Task):
 
     def get_file_extensions(self):
         return ["py"]

--- a/stdlib.py
+++ b/stdlib.py
@@ -4,22 +4,22 @@ and assert.h are exceptions.
 
 import re
 
-from task import Task
+import task
 
 
 class Header(object):
-    """Manages function and type names in standard library header.
-
-    Keyword arguments:
-    name -- header name string
-    func_names -- set of function name strings (default set())
-    type_regexes -- list of type regex strings (default [])
-    add_prefix -- determines whether std:: prefix is added or removed
-                  (default True)
-    """
 
     def __init__(self, name, func_names=set(), type_regexes=[],
                  add_prefix=True):
+        """Manages function and type names in standard library header.
+
+        Keyword arguments:
+        name -- header name string
+        func_names -- set of function name strings (default set())
+        type_regexes -- list of type regex strings (default [])
+        add_prefix -- determines whether std:: prefix is added or removed
+                      (default True)
+        """
         self.name = name
         self.func_names = func_names
         self.add_prefix = add_prefix
@@ -57,11 +57,11 @@ class Header(object):
             self.type_regex = None
 
 
-class Stdlib(Task):
+class Stdlib(task.Task):
 
     def get_file_extensions(self):
-        return Task.get_config("cppHeaderExtensions") + \
-            Task.get_config("cppSrcExtensions")
+        return task.get_config("cppHeaderExtensions") + \
+            task.get_config("cppSrcExtensions")
 
     def run(self, name, lines):
         headers = []
@@ -173,9 +173,8 @@ class Stdlib(Task):
 
         return (lines, file_changed, True)
 
-    """Returns modified lines and whether string changed."""
-
     def func_substitute(self, header, lines):
+        """Returns modified lines and whether string changed."""
         pos = 0
         lines_changed = False
         while pos < len(lines):

--- a/whitespace.py
+++ b/whitespace.py
@@ -2,13 +2,13 @@
 
 import os
 
-from task import Task
+import task
 
 
-class Whitespace(Task):
+class Whitespace(task.Task):
 
     def run(self, name, lines):
-        linesep = Task.get_linesep(lines)
+        linesep = task.get_linesep(lines)
 
         file_changed = False
         output = ""


### PR DESCRIPTION
licenseupdate.py and task.py had similar recursive config file search functions, so this patch combines them in task.py.

There was a circular dependency between the free variables in the task module and the Task class with regard to the config file helper function. This was resolved by making the static member functions in the Task class free functions.

This patch made it apparent the function docstrings were poorly formatted, so I moved them into the function body as per PEP 257.