### PR TITLE
Fixed performance regression

### DIFF
--- a/format.py
+++ b/format.py
@@ -133,11 +133,11 @@ def main():
         print("Error: no files found to format", file=sys.stderr)
         sys.exit(1)
 
-    # Don't check for changes in or run tasks on modifiable or ignored files
-    files = [
-        name for name in files
-        if not task.is_modifiable_file(name) and not task.is_ignored_file(name)
-    ]
+    # Don't check for changes in or run tasks on modifiable files
+    files = [name for name in files if not task.is_modifiable_file(name)]
+
+    # Don't check for changes in or run tasks on ignored files
+    files = task.filter_ignored_files(files)
 
     # Create list of all changed files
     changed_file_list = []


### PR DESCRIPTION
format.py was spawning a "git check-ignore" subprocess for every file name to determine whether to exclude them from processing. This patch sends the whole list of names to one subprocess instead to avoid the overhead of spawning so many processes.

Running `time ./styleguide/format.py` on allwpilib without this patch prints:

real  0m23.357s
user  0m36.937s
sys   0m4.947s

Running `time ./styleguide/format.py` on allwpilib with this patch prints:

real  0m18.978s
user  0m37.587s
sys   0m3.893s