### PR TITLE
clangformat, lint, and pyformat tasks now take a list of file names

### DIFF
--- a/clangformat.py
+++ b/clangformat.py
@@ -13,27 +13,16 @@ class ClangFormat(task.Task):
             task.get_config("cppHeaderExtensions") + \
             task.get_config("cppSrcExtensions")
 
-    def run(self, name, lines):
-        args = ["-assume-filename=" + name, "-style=file", "-"]
+    def run_all(self, names):
+        args = ["-style=file", "-i"] + names
         try:
-            output = self.run_clangformat("clang-format-3.8", args, lines)
+            returncode = subprocess.call(["clang-format-3.8"] + args)
         except FileNotFoundError:
             try:
-                output = self.run_clangformat("clang-format", args, lines)
+                returncode = subprocess.call(["clang-format"] + args)
             except FileNotFoundError:
                 print(
                     "Error: clang-format not found in PATH. Is it installed?",
                     file=sys.stderr)
-                return (lines, False, False)
-
-        if lines == output:
-            return (lines, False, True)
-        else:
-            return (output, True, True)
-
-    @staticmethod
-    def run_clangformat(binary, args, lines):
-        proc = subprocess.Popen(
-            [binary] + args, stdout=subprocess.PIPE, stdin=subprocess.PIPE)
-        output = proc.communicate(lines.encode())[0]
-        return output.decode()
+                return False
+        return returncode == 0

--- a/lint.py
+++ b/lint.py
@@ -22,7 +22,7 @@ class Lint(task.Task):
         return task.get_config("cppHeaderExtensions") + \
             task.get_config("cppSrcExtensions")
 
-    def run(self, name, lines):
+    def run_all(self, names):
         # Handle running in either the root or styleguide directories
         cpplintPrefix = ""
         if os.getcwd().rpartition(os.sep)[2] != "styleguide":
@@ -45,8 +45,7 @@ class Lint(task.Task):
                                  task.get_config("cppSrcExtensions")),
                     "--headers=" + \
                         ",".join(task.get_config("cppHeaderExtensions")),
-                    "--quiet",
-                    name]
+                    "--quiet"] + names
 
         # Run cpplint.py
         try:
@@ -56,4 +55,4 @@ class Lint(task.Task):
             sys.argv = saved_argv
 
             # Report success if error code is 0 (False)
-            return (lines, False, e.code == False)
+            return e.code == False

--- a/pyformat.py
+++ b/pyformat.py
@@ -11,20 +11,13 @@ class PyFormat(task.Task):
     def get_file_extensions(self):
         return ["py"]
 
-    def run(self, name, lines):
-        args = ["yapf", "--style", "google", name]
+    def run_all(self, names):
         try:
-            proc = subprocess.Popen(
-                args, stdout=subprocess.PIPE, stdin=subprocess.PIPE)
-            output = proc.communicate(lines.encode())[0]
-            output = output.decode()
+            returncode = \
+                subprocess.call(["yapf", "--style", "google", "-i"] + names)
         except FileNotFoundError:
             print(
                 "Error: yapf not found in PATH. Is it installed?",
                 file=sys.stderr)
-            return (lines, False, False)
-
-        if lines == output:
-            return (lines, False, True)
-        else:
-            return (output, True, True)
+            return False
+        return True

--- a/task.py
+++ b/task.py
@@ -191,6 +191,17 @@ class Task(object):
         """
         return ("", False, True)
 
+    @abstractmethod
+    def run_all(self, names):
+        """Performs task on list of files.
+
+        Keyword arguments:
+        names -- list of file name strings
+
+        Returns True if task succeeded in formatting the files.
+        """
+        return True
+
     # Returns True if file has an extension this task can process
     def file_matches_extension(self, name):
         if self.get_file_extensions() != []:


### PR DESCRIPTION
I benchmarked the script using `time format.py` in two repositories.

allwpilib without this patch:
  real  0m17.841s
  user  0m36.467s
  sys   0m3.830s

allwpilib with this patch:
  real  0m13.223s
  user  0m31.120s
  sys   0m1.097s

styleguide without this patch:
  real  0m16.998s
  user  0m27.883s
  sys   0m0.567s

styleguide with this patch:
  real  0m7.735s
  user  0m12.433s
  sys   0m0.163s