### PR TITLE
Upgraded clang-format to 3.9 and removed it from Travis build

### DIFF
--- a/wpiformat/README.rst
+++ b/wpiformat/README.rst
@@ -10,7 +10,9 @@ Dependencies
 ============
 
 - `Python 3.4 or newer <https://www.python.org/downloads/>`_
-- clang-format 3.8 or newer (included with `LLVM <http://llvm.org/releases/download.html>`_)
+- clang-format 3.9 or newer (included with `LLVM <http://llvm.org/releases/download.html>`_)
+
+Older Debian and Ubuntu releases do not provide a ``clang-format-3.9`` package. Either upgrade to one that does or add the appropriate ``deb ... main`` line from `apt.llvm.org <http://apt.llvm.org/>`_ to your ``/etc/apt/sources.list``. Then install ``clang-format-3.9``.
 
 If you would like to use these tools with a new project, copy `.styleguide`_, and `.styleguide-license`_ into the project.
 

--- a/wpiformat/wpiformat/clangformat.py
+++ b/wpiformat/wpiformat/clangformat.py
@@ -16,7 +16,7 @@ class ClangFormat(task.Task):
     def run_all(self, names):
         args = ["-style=file", "-i"] + names
         try:
-            returncode = subprocess.call(["clang-format-3.8"] + args)
+            returncode = subprocess.call(["clang-format-3.9"] + args)
         except FileNotFoundError:
             try:
                 returncode = subprocess.call(["clang-format"] + args)


### PR DESCRIPTION
Instructions for installing clang-format 3.9 are provided for users of older distributions of Debian or Ubuntu.

This repository doesn't contain C++ source files, so clang-format is never used. Removing it allows Travis to give up sudo privileges and run shorter builds.