### PR TITLE
.git folder now automatically added to modifiable files list

### DIFF
--- a/.styleguide
+++ b/.styleguide
@@ -23,7 +23,6 @@ genFileExclude {
 }
 
 modifiableFolderExclude {
-  \.git
 }
 
 modifiableFileExclude {

--- a/wpiformat/examples/.styleguide
+++ b/wpiformat/examples/.styleguide
@@ -26,7 +26,6 @@ genFileExclude {
 }
 
 modifiableFolderExclude {
-  \.git
   __pycache__
   folder/subdir
 }

--- a/wpiformat/wpiformat/__init__.py
+++ b/wpiformat/wpiformat/__init__.py
@@ -130,8 +130,12 @@ def main():
         print("Error: no files found to format", file=sys.stderr)
         sys.exit(1)
 
-    # Don't check for changes in or run tasks on modifiable files
-    files = [name for name in files if not task.is_modifiable_file(name)]
+    # Don't check for changes in or run tasks on modifiable files or Git
+    # metadata
+    files = [
+        name for name in files
+        if not task.is_modifiable_file(name) and ".git" + os.sep not in name
+    ]
 
     # Don't check for changes in or run tasks on ignored files
     files = task.filter_ignored_files(files)


### PR DESCRIPTION
This avoids Git repository corruption when "\.git" isn't in the "modifiableFolderExclude" group of the .styleguide file.