### PR TITLE
Made the C system header regex more comprehensive

### DIFF
--- a/wpiformat/README.rst
+++ b/wpiformat/README.rst
@@ -43,6 +43,8 @@ Empty config groups can be omitted. Directory separators must be "/", not "\". D
 
 The groups ``includeRelated``, ``includeCSys``, ``includeCppSys``, ``includeOtherLibs``, and ``includeProject`` correspond to the header groups in the style guide. If a header name matches a regex in one of the groups, it overrides the default ordering and is placed in the corresponding group. The groups of regexes are checked in order of include group precedence.
 
+The regex for C system headers produces false positives on headers from "other libraries". Regexes for them should be added to ``includeOtherLibs``. Libraries with many headers generally group them within a folder, so a regex for just the folder will suffice.
+
 .styleguide-license
 -------------------
 

--- a/wpiformat/wpiformat/includeorder.py
+++ b/wpiformat/wpiformat/includeorder.py
@@ -34,7 +34,7 @@ class IncludeOrder(task.Task):
         ]
 
         # Header type 1: C system headers
-        self.c_sys_regex = re.compile("<[a-z].*\.h>")
+        self.c_sys_regex = re.compile("<[a-z][A-Za-z0-9/_-]*\.h>")
 
         # Header type 2: C++ standard library headers
         self.cpp_std = [


### PR DESCRIPTION
This increases the false positive rate of the regex on headers from other
libraries. Users should be overriding them for sorting guarantees anyway, since
the false positive rate was never zero.