### PR TITLE
Reorganized and generalized config file format

### DIFF
--- a/.styleguide
+++ b/.styleguide
@@ -1,22 +1,14 @@
-cExtensions {
-  c
+cppHeaderFileInclude {
+  \.h$
+  \.inc$
 }
 
-cppHeaderExtensions {
-  h
-  inc
-}
-
-cppSrcExtensions {
-  cpp
-}
-
-otherExtensions {
-  java
+cppSrcFileInclude {
+  \.cpp$
 }
 
 # Extra "/" used by unit tests
-genFileExclude {
+generatedFileExclude {
   /cpplint\.py$
 }
 

--- a/wpiformat/README.rst
+++ b/wpiformat/README.rst
@@ -35,7 +35,7 @@ This file contains groups of file name regular expressions. There are two groups
 - generated files
 - modifiable files
 
-Generated files should not be modified; if they are, wpiformat will emit warnings. No warnings are emitted for modifications to modifiable files. All files ignored by patterns in a repository's .gitignore file are considered modifiable files.
+Generated files should not be modified; if they are, wpiformat will emit warnings. No warnings are emitted for modifications to modifiable files. All files ignored by patterns in a repository's .gitignore file are considered modifiable files. Exclusion groups take precedence over inclusion groups.
 
 File names matching regexes in the group ``licenseUpdateExclude`` will be skipped by the license header update task.
 

--- a/wpiformat/examples/.styleguide
+++ b/wpiformat/examples/.styleguide
@@ -1,21 +1,17 @@
-cExtensions {
-  c
+cHeaderFileInclude {
+  \.h$
 }
 
-cppHeaderExtensions {
-  h
-  inc
+cppHeaderFileInclude {
+  \.hpp$
+  \.inc$
 }
 
-cppSrcExtensions {
-  cpp
+cppSrcFileInclude {
+  \.cpp$
 }
 
-otherExtensions {
-  java
-}
-
-genFileExclude {
+generatedFileExclude {
   folder1/
   folder2/subdir1/subdir2/
   header1\.h$

--- a/wpiformat/wpiformat/clangformat.py
+++ b/wpiformat/wpiformat/clangformat.py
@@ -17,11 +17,7 @@ class ClangFormat(task.Task):
             self.exec_name = "clang-format-" + clang_version
 
     def should_process_file(self, config_file, name):
-        extensions = config_file.group("cExtensions") + \
-            config_file.group("cppHeaderExtensions") + \
-            config_file.group("cppSrcExtensions")
-
-        return any(name.endswith("." + ext) for ext in extensions)
+        return config_file.is_c_file(name) or config_file.is_cpp_file(name)
 
     def run_all(self, config_file, names):
         args = ["-style=file", "-i"] + names

--- a/wpiformat/wpiformat/config.py
+++ b/wpiformat/wpiformat/config.py
@@ -9,7 +9,10 @@ class Config:
 
     def __init__(self, directory, file_name):
         self.__config_dict = self.__parse_config_file(directory, file_name)
-        self.__generated_exclude_regex = self.regex("genFileExclude")
+        self.__c_header_include_regex = self.regex("cHeaderFileInclude")
+        self.__cpp_header_include_regex = self.regex("cppHeaderFileInclude")
+        self.__cpp_src_include_regex = self.regex("cppSrcFileInclude")
+        self.__generated_exclude_regex = self.regex("generatedFileExclude")
         self.__modifiable_exclude_regex = self.regex("modifiableFileExclude")
 
     @staticmethod
@@ -66,14 +69,28 @@ class Config:
         else:
             return re.compile("|".join(group_contents))
 
+    def is_c_file(self, name):
+        """Returns True if file is either C header or C source file."""
+        return self.__c_header_include_regex.search(name) or name.endswith(".c")
+
+    def is_cpp_file(self, name):
+        """Returns True if file is either C++ header or C++ source file."""
+        return self.is_cpp_header_file(name) or self.is_cpp_src_file(name)
+
+    def is_cpp_header_file(self, name):
+        """Returns True if file is C++ header file."""
+        return self.__cpp_header_include_regex.search(name)
+
+    def is_cpp_src_file(self, name):
+        """Returns True if file is C++ source file."""
+        return self.__cpp_src_include_regex.search(name)
+
     def is_generated_file(self, name):
-        """Returns True if file isn't generated (generated files are skipped).
-        """
+        """Returns True if file is generated (generated files are skipped)."""
         return self.__generated_exclude_regex.search(name)
 
     def is_modifiable_file(self, name):
-        """Returns True if file is modifiable but should not have tasks run on it.
-        """
+        """Returns True if file is modifiable but should be skipped."""
         return self.__modifiable_exclude_regex.search(name)
 
     def __parse_config_file(self, directory, file_name):

--- a/wpiformat/wpiformat/includeorder.py
+++ b/wpiformat/wpiformat/includeorder.py
@@ -69,10 +69,7 @@ class IncludeOrder(Task):
         self.ifdef_level = 0
 
     def should_process_file(self, config_file, name):
-        extensions = config_file.group("cppHeaderExtensions") + \
-            config_file.group("cppSrcExtensions")
-
-        return any(name.endswith("." + ext) for ext in extensions)
+        return config_file.is_cpp_file(name)
 
     def classify_header(self, config_file, include_line, file_name):
         """Classify the given header name and return the corresponding index."""
@@ -88,7 +85,7 @@ class IncludeOrder(Task):
         # Is related if include has same base name as file name and file has a
         # source extension
         include_is_related = include_base == file_base and \
-            file_ext[1:] in config_file.group("cppSrcExtensions")
+            config_file.is_cpp_src_file(file_name)
 
         if include_is_related:
             return 0
@@ -107,8 +104,7 @@ class IncludeOrder(Task):
 
     def include_is_header(self, config_file, file_name, include_name):
         """Return True if include name has header extension."""
-        base, ext = os.path.splitext(include_name)
-        if ext[1:] not in config_file.group("cppHeaderExtensions"):
+        if not config_file.is_cpp_header_file(include_name):
             print("Error: " + file_name + ": include '" + include_name + \
                 "' has extension not in header list")
             return False

--- a/wpiformat/wpiformat/licenseupdate.py
+++ b/wpiformat/wpiformat/licenseupdate.py
@@ -16,14 +16,10 @@ class LicenseUpdate(Task):
         self.__current_year = current_year
 
     def should_process_file(self, config_file, name):
-        extensions = config_file.group("cExtensions") + \
-            config_file.group("cppHeaderExtensions") + \
-            config_file.group("cppSrcExtensions") + \
-            config_file.group("otherExtensions")
         license_regex = config_file.regex("licenseUpdateExclude")
 
-        return not license_regex.search(name) and \
-            any(name.endswith("." + ext) for ext in extensions)
+        return (config_file.is_c_file(name) or config_file.is_cpp_file(name) or
+                name.endswith(".java")) and not license_regex.search(name)
 
     def run(self, config_file, name, lines):
         linesep = Task.get_linesep(lines)

--- a/wpiformat/wpiformat/lint.py
+++ b/wpiformat/wpiformat/lint.py
@@ -23,10 +23,7 @@ class Lint(task.Task):
         self.repo_root = repo_root
 
     def should_process_file(self, config_file, name):
-        extensions = config_file.group("cppHeaderExtensions") + \
-            config_file.group("cppSrcExtensions")
-
-        return any(name.endswith("." + ext) for ext in extensions)
+        return config_file.is_cpp_file(name)
 
     def run_all(self, config_file, names):
         # Handle running in either the root or styleguide directories

--- a/wpiformat/wpiformat/namespace.py
+++ b/wpiformat/wpiformat/namespace.py
@@ -8,9 +8,7 @@ from wpiformat.task import Task
 class Namespace(Task):
 
     def should_process_file(self, config_file, name):
-        extensions = config_file.group("cppHeaderExtensions")
-
-        return any(name.endswith("." + ext) for ext in extensions)
+        return config_file.is_cpp_header_file(name)
 
     def run(self, config_file, name, lines):
         linesep = Task.get_linesep(lines)

--- a/wpiformat/wpiformat/stdlib.py
+++ b/wpiformat/wpiformat/stdlib.py
@@ -64,10 +64,7 @@ class Header(object):
 class Stdlib(task.Task):
 
     def should_process_file(self, config_file, name):
-        extensions = config_file.group("cppHeaderExtensions") + \
-            config_file.group("cppSrcExtensions")
-
-        return any(name.endswith("." + ext) for ext in extensions)
+        return config_file.is_cpp_file(name)
 
     def run(self, config_file, name, lines):
         headers = []


### PR DESCRIPTION
Generalized all groups to regexes, added C header group, and removed "cSrc" and
"other" groups since "other" was only ever used for Java source files, and the
extension for both groups never changes.