### PR TITLE
includeorder.py now removes extra newline from #endif

### DIFF
--- a/wpiformat/test/test_includeorder.py
+++ b/wpiformat/test/test_includeorder.py
@@ -310,6 +310,19 @@ def test_includeorder():
         "#endif" + os.linesep + \
         "#endif" + os.linesep, True, True))
 
+    # Verify extra newline from #endif is removed
+    inputs.append(("./Test.h",
+        "#include \"HAL/HAL.h\"" + os.linesep + \
+        "#include \"NotifyListener.h\"" + os.linesep + \
+        os.linesep + \
+        "#ifdef __cplusplus" + os.linesep + \
+        "extern \"C\" {" + os.linesep + \
+        "#endif" + os.linesep + \
+        os.linesep + \
+        "void HALSIM_ResetSPIAccelerometerData(int32_t index);" + \
+        os.linesep))
+    outputs.append((inputs[len(inputs) - 1][1], False, True))
+
     # Large test
     inputs.append(("./UsbCameraImpl.cpp",
         "#include <algorithm>" + os.linesep + \

--- a/wpiformat/wpiformat/includeorder.py
+++ b/wpiformat/wpiformat/includeorder.py
@@ -313,6 +313,9 @@ class IncludeOrder(Task):
         if suboutput:
             output_list.extend(suboutput)
 
+        # Remove possible extra newline from #endif
+        output_list[-1] = output_list[-1].rstrip()
+
         # Write rest of file
         output_list.append("")
         output_list.extend(lines_list[i:])


### PR DESCRIPTION
This wasn't noticed before because clang-format corrected the output. However,
it still led to more file modifications than necessary.