### PR TITLE
Removed cpplint.py check clang-format already handles

### DIFF
--- a/wpiformat/wpiformat/cpplint.py
+++ b/wpiformat/wpiformat/cpplint.py
@@ -1978,15 +1978,6 @@ def CheckComment(line, filename, linenum, next_line_start, error):
   if commentpos != -1:
     # Check if the // may be in quotes.  If so, ignore it
     if re.sub(r'\\.', '', line[0:commentpos]).count('"') % 2 == 0:
-      # Allow one space for new scopes, two spaces otherwise:
-      if (not (Match(r'^.*{ *//', line) and next_line_start == commentpos) and
-          ((commentpos >= 1 and
-            line[commentpos-1] not in string.whitespace) or
-           (commentpos >= 2 and
-            line[commentpos-2] not in string.whitespace))):
-        error(filename, linenum, 'whitespace/comments', 2,
-              'At least two spaces is best between code and comments')
-
       # Checks for common mistakes in TODO comments.
       comment = line[commentpos:]
       match = _RE_PATTERN_TODO.match(comment)


### PR DESCRIPTION
clang-format already ensures at least two spaces or a tab are before comments.
cpplint.py's check is producing false positives.