### PR TITLE
Fixed stdlib.py prepending "std::" to function definitions

### DIFF
--- a/wpiformat/test/test_stdlib.py
+++ b/wpiformat/test/test_stdlib.py
@@ -59,6 +59,10 @@ def test_stdlib():
          "uint64_t time() const { return m_val.last_change; }" + os.linesep))
     outputs.append((inputs[len(inputs) - 1][1], False, True))
 
+    # Test detection of type within static_cast<>
+    inputs.append(("./Test.cpp", "static_cast<std::uint64_t>(x);" + os.linesep))
+    outputs.append(("static_cast<uint64_t>(x);" + os.linesep, True, True))
+
     # Types followed by semicolon should match
     inputs.append(("./Main.cpp", "typedef integer std::uint8_t;"))
     outputs.append(("typedef integer uint8_t;", True, True))

--- a/wpiformat/test/test_stdlib.py
+++ b/wpiformat/test/test_stdlib.py
@@ -53,6 +53,12 @@ def test_stdlib():
         "#define FILE_LOG(level)" + os.linesep + \
         "if (level > FILELog::ReportingLevel())" + os.linesep, False, True))
 
+    # Don't prepend "std::" to function name if it's a function definition
+    inputs.append(
+        ("./Test.cpp",
+         "uint64_t time() const { return m_val.last_change; }" + os.linesep))
+    outputs.append((inputs[len(inputs) - 1][1], False, True))
+
     # Types followed by semicolon should match
     inputs.append(("./Main.cpp", "typedef integer std::uint8_t;"))
     outputs.append(("typedef integer uint8_t;", True, True))

--- a/wpiformat/wpiformat/stdlib.py
+++ b/wpiformat/wpiformat/stdlib.py
@@ -36,9 +36,12 @@ class Header(object):
 
         if func_names != []:
             # Matches C standard library function uses. C standard library
-            # function names are alphanumeric and start with a letter.
+            # function names are alphanumeric and start with a letter. If the
+            # function name is preceded by a word character and a space, it's
+            # a function definition instead of a usage.
             self.func_regex = re.compile(
-                "(?: |,|\()" +  # Preceded by space, comma, or "("
+                "(?:[^\w]\s+|,|\()"
+                +  # Preceded by nonword character and spaces, comma, or "("
                 regex_prefix + "([a-z][a-z0-9]*)" +  # C stdlib function name
                 "(?:\()"  # Followed by open parenthesis
             )

--- a/wpiformat/wpiformat/stdlib.py
+++ b/wpiformat/wpiformat/stdlib.py
@@ -51,14 +51,14 @@ class Header(object):
         if type_regexes != []:
             # Type uses are preceded by a left angle bracket (template), a
             # space, a comma, or an open parenthesis. Type names are followed by
-            # a close parenthesis, a comma, a semicolon, a space, or pointer
-            # asterisks.
+            # a right angle bracket, close parenthesis, a comma, a semicolon, a
+            # space, or pointer asterisks.
             # FIXME: Types at the beginning of the line are not matched.
             self.type_regex = re.compile(
                 "(?<=\<| |,|\()" +  #  Preceded by space, comma, or "("
                 regex_prefix + "(" + "|".join(type_regexes) + ")"  # Type names
                 +
-                "(?=\)|,|;| |\*+)"  # Followed by ")", ",", ";", " ", or pointer asterisks
+                "(?=\>|\)|,|;| |\*+)"  # Followed by ">", ")", ",", ";", " ", or pointer asterisks
             )
         else:
             self.type_regex = None


### PR DESCRIPTION
Previously, function definitions sharing a name with a standard library
function had "std::" prepended to it. stdlib.py should only modify function
uses.