### PR TITLE
Make IntelliJ Java style get read properly

### DIFF
--- a/intellij-java-google-style.xml
+++ b/intellij-java-google-style.xml
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <code_scheme name="GoogleStyle">
     <option name="JAVA_INDENT_OPTIONS">
-    <value>
-      <option name="INDENT_SIZE" value="2" />
-      <option name="CONTINUATION_INDENT_SIZE" value="4" />
-      <option name="TAB_SIZE" value="2" />
-      <option name="USE_TAB_CHARACTER" value="false" />
-      <option name="SMART_TABS" value="false" />
-      <option name="LABEL_INDENT_SIZE" value="0" />
-      <option name="LABEL_INDENT_ABSOLUTE" value="false" />
-      <option name="USE_RELATIVE_INDENTS" value="false" />
-    </value>
-  </option>
+        <value>
+          <option name="INDENT_SIZE" value="2" />
+          <option name="CONTINUATION_INDENT_SIZE" value="4" />
+          <option name="TAB_SIZE" value="2" />
+          <option name="USE_TAB_CHARACTER" value="false" />
+          <option name="SMART_TABS" value="false" />
+          <option name="LABEL_INDENT_SIZE" value="0" />
+          <option name="LABEL_INDENT_ABSOLUTE" value="false" />
+          <option name="USE_RELATIVE_INDENTS" value="false" />
+        </value>
+    </option>
     <option name="CLASS_COUNT_TO_USE_IMPORT_ON_DEMAND" value="99" />
     <option name="NAMES_COUNT_TO_USE_IMPORT_ON_DEMAND" value="99" />
     <option name="IMPORT_LAYOUT_TABLE">

--- a/intellij-java-google-style.xml
+++ b/intellij-java-google-style.xml
@@ -306,18 +306,18 @@
         <option name="LABEL_INDENT_ABSOLUTE" value="false" />
         <option name="USE_RELATIVE_INDENTS" value="false" />
     </ADDITIONAL_INDENT_OPTIONS>
-	<codeStyleSettings language="JAVA">
-    <indentOptions>
-        <option name="INDENT_SIZE" value="2" />
-        <option name="CONTINUATION_INDENT_SIZE" value="4" />
-        <option name="TAB_SIZE" value="2" />
-        <option name="USE_TAB_CHARACTER" value="false" />
-        <option name="SMART_TABS" value="false" />
-        <option name="LABEL_INDENT_SIZE" value="0" />
-        <option name="LABEL_INDENT_ABSOLUTE" value="false" />
-        <option name="USE_RELATIVE_INDENTS" value="false" />
-    </indentOptions>
-  </codeStyleSettings>
+    <codeStyleSettings language="JAVA">
+        <indentOptions>
+            <option name="INDENT_SIZE" value="2" />
+            <option name="CONTINUATION_INDENT_SIZE" value="4" />
+            <option name="TAB_SIZE" value="2" />
+            <option name="USE_TAB_CHARACTER" value="false" />
+            <option name="SMART_TABS" value="false" />
+            <option name="LABEL_INDENT_SIZE" value="0" />
+            <option name="LABEL_INDENT_ABSOLUTE" value="false" />
+            <option name="USE_RELATIVE_INDENTS" value="false" />
+        </indentOptions>
+    </codeStyleSettings>
     <ADDITIONAL_INDENT_OPTIONS fileType="js">
         <option name="INDENT_SIZE" value="4" />
         <option name="CONTINUATION_INDENT_SIZE" value="4" />

--- a/intellij-java-google-style.xml
+++ b/intellij-java-google-style.xml
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <code_scheme name="GoogleStyle">
     <option name="JAVA_INDENT_OPTIONS">
-        <value>
-            <option name="INDENT_SIZE" value="2" />
-            <option name="CONTINUATION_INDENT_SIZE" value="4" />
-            <option name="TAB_SIZE" value="8" />
-            <option name="USE_TAB_CHARACTER" value="false" />
-            <option name="SMART_TABS" value="false" />
-            <option name="LABEL_INDENT_SIZE" value="0" />
-            <option name="LABEL_INDENT_ABSOLUTE" value="false" />
-            <option name="USE_RELATIVE_INDENTS" value="false" />
-        </value>
-    </option>
+    <value>
+      <option name="INDENT_SIZE" value="2" />
+      <option name="CONTINUATION_INDENT_SIZE" value="4" />
+      <option name="TAB_SIZE" value="2" />
+      <option name="USE_TAB_CHARACTER" value="false" />
+      <option name="SMART_TABS" value="false" />
+      <option name="LABEL_INDENT_SIZE" value="0" />
+      <option name="LABEL_INDENT_ABSOLUTE" value="false" />
+      <option name="USE_RELATIVE_INDENTS" value="false" />
+    </value>
+  </option>
     <option name="CLASS_COUNT_TO_USE_IMPORT_ON_DEMAND" value="99" />
     <option name="NAMES_COUNT_TO_USE_IMPORT_ON_DEMAND" value="99" />
     <option name="IMPORT_LAYOUT_TABLE">
@@ -306,16 +306,18 @@
         <option name="LABEL_INDENT_ABSOLUTE" value="false" />
         <option name="USE_RELATIVE_INDENTS" value="false" />
     </ADDITIONAL_INDENT_OPTIONS>
-    <ADDITIONAL_INDENT_OPTIONS fileType="java">
+	<codeStyleSettings language="JAVA">
+    <indentOptions>
         <option name="INDENT_SIZE" value="2" />
         <option name="CONTINUATION_INDENT_SIZE" value="4" />
-        <option name="TAB_SIZE" value="8" />
+        <option name="TAB_SIZE" value="2" />
         <option name="USE_TAB_CHARACTER" value="false" />
         <option name="SMART_TABS" value="false" />
         <option name="LABEL_INDENT_SIZE" value="0" />
         <option name="LABEL_INDENT_ABSOLUTE" value="false" />
         <option name="USE_RELATIVE_INDENTS" value="false" />
-    </ADDITIONAL_INDENT_OPTIONS>
+    </indentOptions>
+  </codeStyleSettings>
     <ADDITIONAL_INDENT_OPTIONS fileType="js">
         <option name="INDENT_SIZE" value="4" />
         <option name="CONTINUATION_INDENT_SIZE" value="4" />

--- a/intellij-java-google-style.xml
+++ b/intellij-java-google-style.xml
@@ -2,14 +2,14 @@
 <code_scheme name="GoogleStyle">
     <option name="JAVA_INDENT_OPTIONS">
         <value>
-          <option name="INDENT_SIZE" value="2" />
-          <option name="CONTINUATION_INDENT_SIZE" value="4" />
-          <option name="TAB_SIZE" value="2" />
-          <option name="USE_TAB_CHARACTER" value="false" />
-          <option name="SMART_TABS" value="false" />
-          <option name="LABEL_INDENT_SIZE" value="0" />
-          <option name="LABEL_INDENT_ABSOLUTE" value="false" />
-          <option name="USE_RELATIVE_INDENTS" value="false" />
+            <option name="INDENT_SIZE" value="2" />
+            <option name="CONTINUATION_INDENT_SIZE" value="4" />
+            <option name="TAB_SIZE" value="2" />
+            <option name="USE_TAB_CHARACTER" value="false" />
+            <option name="SMART_TABS" value="false" />
+            <option name="LABEL_INDENT_SIZE" value="0" />
+            <option name="LABEL_INDENT_ABSOLUTE" value="false" />
+            <option name="USE_RELATIVE_INDENTS" value="false" />
         </value>
     </option>
     <option name="CLASS_COUNT_TO_USE_IMPORT_ON_DEMAND" value="99" />
@@ -287,14 +287,14 @@
     <option name="WHILE_BRACE_FORCE" value="3" />
     <option name="FOR_BRACE_FORCE" value="3" />
     <ADDITIONAL_INDENT_OPTIONS fileType="css">
-        <option name="INDENT_SIZE" value="4" />
-        <option name="CONTINUATION_INDENT_SIZE" value="8" />
-        <option name="TAB_SIZE" value="4" />
-        <option name="USE_TAB_CHARACTER" value="false" />
-        <option name="SMART_TABS" value="false" />
-        <option name="LABEL_INDENT_SIZE" value="0" />
-        <option name="LABEL_INDENT_ABSOLUTE" value="false" />
-        <option name="USE_RELATIVE_INDENTS" value="false" />
+    <option name="INDENT_SIZE" value="4" />
+    <option name="CONTINUATION_INDENT_SIZE" value="8" />
+    <option name="TAB_SIZE" value="4" />
+    <option name="USE_TAB_CHARACTER" value="false" />
+    <option name="SMART_TABS" value="false" />
+    <option name="LABEL_INDENT_SIZE" value="0" />
+    <option name="LABEL_INDENT_ABSOLUTE" value="false" />
+    <option name="USE_RELATIVE_INDENTS" value="false" />
     </ADDITIONAL_INDENT_OPTIONS>
     <ADDITIONAL_INDENT_OPTIONS fileType="haml">
         <option name="INDENT_SIZE" value="2" />

--- a/intellij-java-google-style.xml
+++ b/intellij-java-google-style.xml
@@ -287,14 +287,14 @@
     <option name="WHILE_BRACE_FORCE" value="3" />
     <option name="FOR_BRACE_FORCE" value="3" />
     <ADDITIONAL_INDENT_OPTIONS fileType="css">
-    <option name="INDENT_SIZE" value="4" />
-    <option name="CONTINUATION_INDENT_SIZE" value="8" />
-    <option name="TAB_SIZE" value="4" />
-    <option name="USE_TAB_CHARACTER" value="false" />
-    <option name="SMART_TABS" value="false" />
-    <option name="LABEL_INDENT_SIZE" value="0" />
-    <option name="LABEL_INDENT_ABSOLUTE" value="false" />
-    <option name="USE_RELATIVE_INDENTS" value="false" />
+        <option name="INDENT_SIZE" value="4" />
+        <option name="CONTINUATION_INDENT_SIZE" value="8" />
+        <option name="TAB_SIZE" value="4" />
+        <option name="USE_TAB_CHARACTER" value="false" />
+        <option name="SMART_TABS" value="false" />
+        <option name="LABEL_INDENT_SIZE" value="0" />
+        <option name="LABEL_INDENT_ABSOLUTE" value="false" />
+        <option name="USE_RELATIVE_INDENTS" value="false" />
     </ADDITIONAL_INDENT_OPTIONS>
     <ADDITIONAL_INDENT_OPTIONS fileType="haml">
         <option name="INDENT_SIZE" value="2" />


### PR DESCRIPTION
Indent size should be 2 and continuation should be 4. My XML uses the correct tags. IntelliJ was ignoring the previous tags so the indentation size, etc. were not being set.