### PR TITLE
Added script for publishing wpiformat to pypi.org

### DIFF
--- a/publish-wpiformat.sh
+++ b/publish-wpiformat.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+pushd wpiformat
+rm -rf dist
+git checkout master
+if [ $? == 0 ]; then
+  python setup.py sdist bdist_wheel
+  twine upload dist/*
+fi
+popd


### PR DESCRIPTION
An unstable PR branch was pushed to pypi.org in place of master recently by
mistake. To avoid this in the future, this commit adds a script that ensures
master is checked out first then runs the commands required to build and
publish the package.