### PR TITLE
Tokens with newlines in a singleline comment now end the comment

### DIFF
--- a/wpiformat/test/test_cidentlist.py
+++ b/wpiformat/test/test_cidentlist.py
@@ -267,6 +267,26 @@ def test_cidentlist():
     test.add_input("./Test.cpp", "void func() { std::cout << '\\\\'; }")
     test.add_latest_input_as_output(True)
 
+    # Ensure extern "C" match containing a linesep within a singleline comment
+    # still ends the comment
+    test.add_input("./Test.cpp",
+        "extern \"C\" {}  // extern \"C\"" + os.linesep + \
+        "namespace {" + os.linesep + \
+        "}  // namespace" + os.linesep)
+    test.add_latest_input_as_output(True)
+
+    # Ensure extern "C" with brace on next line gets matched
+    test.add_input("./Test.cpp",
+        "extern \"C\"" + os.linesep + \
+        "{" + os.linesep + \
+        "  void func() {}" + os.linesep + \
+        "}  // extern \"C\"" + os.linesep)
+    test.add_output(
+        "extern \"C\"" + os.linesep + \
+        "{" + os.linesep + \
+        "  void func(void) {}" + os.linesep + \
+        "}  // extern \"C\"" + os.linesep, True, True)
+
     # Test logic for deduplicating braces within #ifdef
     test.add_input("./Test.cpp",
         "void func() {" + os.linesep + \

--- a/wpiformat/wpiformat/cidentlist.py
+++ b/wpiformat/wpiformat/cidentlist.py
@@ -9,7 +9,8 @@ class CIdentList(Task):
 
     def __print_failure(self, name):
         print("Error: " + name + ": unmatched curly braces when scanning for "
-              "C identifier lists")
+              "C identifier lists. If the code compiles, this is a bug in "
+              "wpiformat.")
 
     def should_process_file(self, config_file, name):
         return config_file.is_c_file(name) or config_file.is_cpp_file(name)
@@ -85,9 +86,10 @@ class CIdentList(Task):
             elif token == "//":
                 if not in_multicomment and not in_string and not in_char:
                     in_singlecomment = True
-            elif token == linesep:
-                if not in_multicomment:
-                    in_singlecomment = False
+            elif in_singlecomment and linesep in token:
+                # Ignore token if it's in a singleline comment. Only check it
+                # for newlines to end the comment.
+                in_singlecomment = False
             elif in_multicomment or in_singlecomment:
                 # Tokens processed after this branch are ignored if they are in
                 # comments

--- a/wpiformat/wpiformat/usingdeclaration.py
+++ b/wpiformat/wpiformat/usingdeclaration.py
@@ -37,9 +37,10 @@ class UsingDeclaration(Task):
             elif token == "//":
                 if not in_multicomment and not in_string and not in_char:
                     in_singlecomment = True
-            elif token == linesep:
-                if not in_multicomment:
-                    in_singlecomment = False
+            elif in_singlecomment and linesep in token:
+                # Ignore token if it's in a singleline comment. Only check it
+                # for newlines to end the comment.
+                in_singlecomment = False
             elif in_multicomment or in_singlecomment:
                 # Tokens processed after this branch are ignored if they are in
                 # comments


### PR DESCRIPTION
This previously caused braces on the next line to be skipped when they
shouldn't be. The failure print now also suggests this occurence is a
wpiformat bug.