### PR TITLE
Moved clang-format cleanup tasks to immediately after ClangFormat task

### DIFF
--- a/wpiformat/wpiformat/__init__.py
+++ b/wpiformat/wpiformat/__init__.py
@@ -364,12 +364,16 @@ def main():
     ]
     run_pipeline(task_pipeline, args, files)
 
-    # Lint is run last since previous tasks can affect its output.
-    task_pipeline = [ClangFormat(args.clang_version), PyFormat(), Lint()]
+    task_pipeline = [ClangFormat(args.clang_version)]
     run_batch(task_pipeline, args, file_batches)
 
+    # These tasks fix clang-format formatting
     task_pipeline = [Jni()]
     run_pipeline(task_pipeline, args, files)
+
+    # Lint is run last since previous tasks can affect its output.
+    task_pipeline = [PyFormat(), Lint()]
+    run_batch(task_pipeline, args, file_batches)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Previously, if a task between ClangFormat and the clang-format cleanup
tasks like Jni threw an error, wpiformat would exit immediately and the
formatting would remain incorrect. Now, the cleanup tasks run immediately
after ClangFormat. Since they don't throw errors, the formatting should remain
consistent even after error conditions.