### PR TITLE
Fixed extra newlines being inserted after NOLINT headers

### DIFF
--- a/wpiformat/test/test_includeorder.py
+++ b/wpiformat/test/test_includeorder.py
@@ -46,6 +46,28 @@ def test_includeorder():
         "#include <iostream>" + os.linesep + \
         "#include <memory>" + os.linesep, True, True)
 
+    # Ensure NOLINT headers have newlines around them
+    test.add_input("./Test.h",
+        "#include \"ctre/PDP.h\"  // NOLINT" + os.linesep + \
+        "#include \"gtest/gtest.h\"  // NOLINT" + os.linesep + \
+        os.linesep + \
+        "#include <iostream>" + os.linesep)
+    test.add_output(
+        "#include \"ctre/PDP.h\"  // NOLINT" + os.linesep + \
+        os.linesep + \
+        "#include \"gtest/gtest.h\"  // NOLINT" + os.linesep + \
+        os.linesep + \
+        "#include <iostream>" + os.linesep, True, True)
+
+    # Ensure NOLINT headers don't have extra newlines inserted after them
+    test.add_input("./Test.h",
+        "#include \"ctre/PDP.h\"  // NOLINT" + os.linesep + \
+        os.linesep + \
+        "#include \"gtest/gtest.h\"  // NOLINT" + os.linesep + \
+        os.linesep + \
+        "namespace wpi {" + os.linesep)
+    test.add_latest_input_as_output(True)
+
     # Ensure NOLINT headers take precedence over overrides and have newline
     # inserted
     test.add_input("./Test.h",

--- a/wpiformat/wpiformat/includeorder.py
+++ b/wpiformat/wpiformat/includeorder.py
@@ -379,6 +379,10 @@ class IncludeOrder(Task):
         if suboutput:
             output_list.extend(suboutput)
 
+        # Remove extra empty lines from end of includes
+        while len(output_list) > 0 and output_list[-1].rstrip() == "":
+            del output_list[-1]  # Remove last newline
+
         # Remove possible extra newline from #endif
         if len(output_list) > 0:
             output_list[-1] = output_list[-1].rstrip()


### PR DESCRIPTION
Blank lines are now stripped from the end of the includes section before
appending a newline with the rest of the file. Also, more tests were added
for NOLINT headers.