### PR TITLE
Fix licenseupdate.py not detecting licenses which don't contain "Copyright"

### DIFF
--- a/wpiformat/test/test_licenseupdate.py
+++ b/wpiformat/test/test_licenseupdate.py
@@ -158,6 +158,16 @@ def test_licenseupdate():
         "/* Copyright (c) Company Name 2011-{}. */".format(year) + os.linesep +
         os.linesep + file_appendix, False, True)
 
+    # Ensure license regex matches
+    test.add_input("./Test.h",
+        "/* Company Name */" + os.linesep + \
+        "/* Copyright (c) 1992-2015 Company Name. All Rights Reserved. */" + os.linesep + \
+        os.linesep + file_appendix)
+    test.add_output(
+        "/*                                Company Name                                */" + os.linesep + \
+        "/* Copyright (c) 1992-2018 Company Name. All Rights Reserved.                 */" + os.linesep + \
+        os.linesep + file_appendix, True, True)
+
     # Ensure excluded files won't be processed
     config_file = Config(os.path.abspath(os.getcwd()), ".styleguide")
     assert not task.should_process_file(config_file, "./Excluded.h")

--- a/wpiformat/wpiformat/licenseupdate.py
+++ b/wpiformat/wpiformat/licenseupdate.py
@@ -26,11 +26,51 @@ class LicenseUpdate(Task):
         return (config_file.is_c_file(name) or config_file.is_cpp_file(name) or
                 name.endswith(".java")) and not license_regex.search(name)
 
-    def run_pipeline(self, config_file, name, lines):
+    def __try_regex(self, lines, license_template):
+        """Try finding license with regex of license template.
+
+        Keyword arguments:
+        lines -- lines of file
+        license_template -- license_template string
+
+        Returns:
+        Tuple of whether license was found, year, and file contents after license.
+        """
         linesep = Task.get_linesep(lines)
 
-        license_template = Config.read_file(
-            os.path.dirname(os.path.abspath(name)), ".styleguide-license")
+        # Convert the license template to a regex
+        license_rgxstr = "^" + linesep.join(license_template)
+        license_rgxstr = license_rgxstr.replace("*", "\*").replace(
+            ".", "\.").replace("(", "\(").replace(")", "\)").replace(
+                "{year}", "(?P<year>[0-9]+)(-[0-9]+)?").replace(
+                    "{padding}", "[ ]*")
+        license_rgx = regex.compile(license_rgxstr, regex.M)
+
+        # Compare license
+        year = self.__current_year
+        match = license_rgx.search(lines)
+        if match:
+            try:
+                year = match.group("year")
+            except IndexError:
+                pass
+
+            # If comment at beginning of file is non-empty license, update it
+            return (True, year, linesep + lines[match.end():].lstrip())
+        else:
+            return (False, year, lines)
+
+    def __try_string_search(self, lines, license_template):
+        """Try finding license with string search.
+
+        Keyword arguments:
+        lines -- lines of file
+        license_template -- license_template string
+
+        Returns:
+        Tuple of whether license was found, year, and file contents after license.
+        """
+        linesep = Task.get_linesep(lines)
 
         # Strip newlines at top of file
         stripped_lines = lines.lstrip().split(linesep)
@@ -46,7 +86,8 @@ class LicenseUpdate(Task):
 
         in_multiline_comment = False
         for line in stripped_lines:
-            # If part of comment contains "Copyright (c)", comment is license.
+            # If part of comment contains "Copyright (c)", comment is
+            # license.
             if "Copyright (c)" in line:
                 first_comment_is_license = True
 
@@ -67,30 +108,39 @@ class LicenseUpdate(Task):
                 license_end += 1
 
         # If comment at beginning of file is non-empty license, update it
-        if first_comment_is_license and license_end > 0:
-            file_parts = \
-                [linesep.join(stripped_lines[0:license_end]),
-                 linesep + linesep.join(stripped_lines[license_end:]).lstrip()]
-        else:
-            file_parts = ["", linesep + lines.lstrip()]
-
-        # Default year when none is found is current one
         year = self.__current_year
+        if first_comment_is_license and license_end > 0:
+            license_part = linesep.join(stripped_lines[0:license_end])
+            appendix_part = \
+                linesep + linesep.join(stripped_lines[license_end:]).lstrip()
 
-        year_regex = regex.compile("Copyright \(c\)(?>.*?\s(20..))")
-        modify_copyright = False
-        for line in file_parts[0].split(linesep):
-            match = year_regex.search(line)
-            # If license contains copyright pattern, extract the first year
-            if match:
-                year = match.group(1)
-                modify_copyright = True
-                break
+            year_regex = regex.compile("Copyright \(c\)(?>.*?\s(20..))")
+            for line in license_part.split(linesep):
+                match = year_regex.search(line)
+                # If license contains copyright pattern, extract the first year
+                if match:
+                    year = match.group(1)
+                    break
+
+            return (True, year, appendix_part)
+        else:
+            return (False, year, linesep + lines.lstrip())
+
+    def run_pipeline(self, config_file, name, lines):
+        linesep = Task.get_linesep(lines)
+
+        license_template = Config.read_file(
+            os.path.dirname(os.path.abspath(name)), ".styleguide-license")
+
+        success, year, appendix = self.__try_regex(lines, license_template)
+        if not success:
+            success, year, appendix = self.__try_string_search(
+                lines, license_template)
 
         output = ""
 
         # Determine copyright range and trailing padding
-        if modify_copyright and year != self.__current_year:
+        if year != self.__current_year:
             year = year + "-" + self.__current_year
 
         for line in license_template:
@@ -110,7 +160,6 @@ class LicenseUpdate(Task):
             output += line + linesep
 
         # Copy rest of original file into new one
-        if len(file_parts) > 1:
-            output += file_parts[1]
+        output += appendix
 
         return (output, lines != output, True)


### PR DESCRIPTION
The contents of .styleguide-license is now compared against the
beginning of the file as well to determine whether a license is there.