### PR TITLE
Fix class keyword in comment breaking javaclass.py

### DIFF
--- a/wpiformat/test/test_javaclass.py
+++ b/wpiformat/test/test_javaclass.py
@@ -43,4 +43,26 @@ def test_javaclass():
         "  public ExampleCommand() {}" + os.linesep + \
         "}" + os.linesep, True, True)
 
+    # class keyword in preceding comment to ensure regex matching it doesn't
+    # continue past end of comment
+    test.add_input("./Test.java",
+        "import edu.wpi.first.networktables.NetworkTableEntry;" + os.linesep + \
+        "import edu.wpi.first.wpilibj.Sendable;" + os.linesep + \
+        os.linesep + \
+        "/**" + os.linesep + \
+        " * A helper class for Shuffleboard containers to handle common child operations." + os.linesep + \
+        " */" + os.linesep + \
+        "final class ContainerHelper {" + os.linesep + \
+        os.linesep + \
+        "  private final ShuffleboardContainer m_container;" + os.linesep)
+    test.add_output(
+        "import edu.wpi.first.networktables.NetworkTableEntry;" + os.linesep + \
+        "import edu.wpi.first.wpilibj.Sendable;" + os.linesep + \
+        os.linesep + \
+        "/**" + os.linesep + \
+        " * A helper class for Shuffleboard containers to handle common child operations." + os.linesep + \
+        " */" + os.linesep + \
+        "final class ContainerHelper {" + os.linesep + \
+        "  private final ShuffleboardContainer m_container;" + os.linesep, True, True)
+
     test.run(OutputType.FILE)

--- a/wpiformat/wpiformat/javaclass.py
+++ b/wpiformat/wpiformat/javaclass.py
@@ -18,7 +18,7 @@ class JavaClass(Task):
         pos = 0
 
         # Match two or more line separators
-        token_str = "/\*|\*/|//|" + linesep + "|class\s[^{]*{" + linesep + "(?P<extra>(" + linesep + ")+)"
+        token_str = "/\*|\*/|//|" + linesep + "|class\s[\w\d\s]*{" + linesep + "(?P<extra>(" + linesep + ")+)"
         token_regex = regex.compile(token_str)
 
         in_multicomment = False


### PR DESCRIPTION
When the regex was matching a class keyword in a comment, it would match
to the next "{", which could be beyond the end of the comment. The
characters matched now only include valid class names.