### PR TITLE
Remove redundant year flag (-y)

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -10,7 +10,7 @@ resources:
     options: "--name ci-container -v /usr/bin/docker:/tmp/docker:ro"
 
 jobs:
-  - job: Styleguide
+  - job: Linux
     pool:
       vmImage: 'Ubuntu 16.04'
 
@@ -32,17 +32,27 @@ jobs:
             sudo python3 setup.py install --optimize=1 --skip-build
           displayName: 'Build'
         - script: |
+            # Make sure .git/refs/heads/master exists
+            git config --global user.email "you@example.com"
+            git config --global user.name "Your Name"
+            git checkout -b pr
+            git checkout master
+            git checkout pr
+
+            cd wpiformat
             python3 setup.py test
+            cd ..
+
             python3 -m wpiformat -v
             cd wpiformat
             # One file
-            python3 -m wpiformat -f wpiformat\__init__.py -v
+            python3 -m wpiformat -f wpiformat/__init__.py -v
 
             # Absolute path to file
-            python3 -m wpiformat -f C:\projects\styleguide\wpiformat\wpiformat\__init__.py -v
+            python3 -m wpiformat -f /__w/1/s/wpiformat/wpiformat/__init__.py -v
 
             # Multiple files
-            python3 -m wpiformat -f wpiformat\__init__.py wpiformat\__main__.py -v
+            python3 -m wpiformat -f wpiformat/__init__.py wpiformat/__main__.py -v
 
             # Directory
             python3 -m wpiformat -f wpiformat -v
@@ -51,7 +61,7 @@ jobs:
             git --no-pager diff --exit-code HEAD
           displayName: 'Test'
 
-  - job: WindowsStyleguide
+  - job: Windows
     pool:
       vmImage: 'vs2017-win2016'
 
@@ -66,14 +76,24 @@ jobs:
           py -3 setup.py install --optimize=1 --skip-build
         displayName: 'Build'
       - powershell: |
+          # Make sure .git/refs/heads/master exists
+          git config --global user.email "you@example.com"
+          git config --global user.name "Your Name"
+          git checkout -b pr
+          git checkout master
+          git checkout pr
+
+          cd wpiformat
           py -3 setup.py test
+          cd ..
+
           py -3 -m wpiformat -v
           cd wpiformat
           # One file
           py -3 -m wpiformat -f wpiformat\__init__.py -v
 
           # Absolute path to file
-          py -3 -m wpiformat -f C:\projects\styleguide\wpiformat\wpiformat\__init__.py -v
+          py -3 -m wpiformat -f D:\a\1\s\wpiformat\wpiformat\__init__.py -v
 
           # Multiple files
           py -3 -m wpiformat -f wpiformat\__init__.py wpiformat\__main__.py -v

--- a/wpiformat/test/test_includeguard.py
+++ b/wpiformat/test/test_includeguard.py
@@ -2,10 +2,13 @@ import os
 
 from test.tasktest import *
 from wpiformat.includeguard import IncludeGuard
+from wpiformat.task import Task
 
 
 def test_includeguard():
     test = TaskTest(IncludeGuard())
+
+    repo_root = os.path.basename(Task.get_repo_root()).upper()
 
     # Fix incorrect include guard
     test.add_input("./Test.h",
@@ -14,10 +17,10 @@ def test_includeguard():
         os.linesep + \
         "#endif" + os.linesep)
     test.add_output(
-        "#ifndef STYLEGUIDE_TEST_H_" + os.linesep + \
-        "#define STYLEGUIDE_TEST_H_" + os.linesep + \
+        "#ifndef " + repo_root + "_TEST_H_" + os.linesep + \
+        "#define " + repo_root + "_TEST_H_" + os.linesep + \
         os.linesep + \
-        "#endif  // STYLEGUIDE_TEST_H_" + os.linesep, True, True)
+        "#endif  // " + repo_root + "_TEST_H_" + os.linesep, True, True)
 
     # Ensure nested preprocessor statements are handled properly for incorrect
     # include guard
@@ -30,20 +33,20 @@ def test_includeguard():
         "#endif" + os.linesep + \
         "#endif" + os.linesep)
     test.add_output(
-        "#ifndef STYLEGUIDE_TEST_H_" + os.linesep + \
-        "#define STYLEGUIDE_TEST_H_" + os.linesep + \
+        "#ifndef " + repo_root + "_TEST_H_" + os.linesep + \
+        "#define " + repo_root + "_TEST_H_" + os.linesep + \
         os.linesep + \
         "#if SOMETHING" + os.linesep + \
         "// do something" + os.linesep + \
         "#endif" + os.linesep + \
-        "#endif  // STYLEGUIDE_TEST_H_" + os.linesep, True, True)
+        "#endif  // " + repo_root + "_TEST_H_" + os.linesep, True, True)
 
     # Don't touch correct include guard
     test.add_input("./Test.h",
-        "#ifndef STYLEGUIDE_TEST_H_" + os.linesep + \
-        "#define STYLEGUIDE_TEST_H_" + os.linesep + \
+        "#ifndef " + repo_root + "_TEST_H_" + os.linesep + \
+        "#define " + repo_root + "_TEST_H_" + os.linesep + \
         os.linesep + \
-        "#endif  // STYLEGUIDE_TEST_H_" + os.linesep)
+        "#endif  // " + repo_root + "_TEST_H_" + os.linesep)
     test.add_latest_input_as_output(True)
 
     # Fail on missing include guard
@@ -56,27 +59,27 @@ def test_includeguard():
 
     # Ensure include guard roots are processed correctly
     test.add_input("./Test.h",
-        "#ifndef STYLEGUIDE_WPIFORMAT_TEST_H_" + os.linesep + \
-        "#define STYLEGUIDE_WPIFORMAT_TEST_H_" + os.linesep + \
+        "#ifndef " + repo_root + "_WPIFORMAT_TEST_H_" + os.linesep + \
+        "#define " + repo_root + "_WPIFORMAT_TEST_H_" + os.linesep + \
         os.linesep + \
-        "#endif  // STYLEGUIDE_WPIFORMAT_TEST_H_" + os.linesep)
+        "#endif  // " + repo_root + "_WPIFORMAT_TEST_H_" + os.linesep)
     test.add_output(
-        "#ifndef STYLEGUIDE_TEST_H_" + os.linesep + \
-        "#define STYLEGUIDE_TEST_H_" + os.linesep + \
+        "#ifndef " + repo_root + "_TEST_H_" + os.linesep + \
+        "#define " + repo_root + "_TEST_H_" + os.linesep + \
         os.linesep + \
-        "#endif  // STYLEGUIDE_TEST_H_" + os.linesep, True, True)
+        "#endif  // " + repo_root + "_TEST_H_" + os.linesep, True, True)
 
     # Ensure leading underscores are removed (this occurs if the user doesn't
     # include a trailing "/" in the include guard root)
     test.add_input("./Test/Test.h",
-        "#ifndef STYLEGUIDE_WPIFORMAT_TEST_TEST_H_" + os.linesep + \
-        "#define STYLEGUIDE_WPIFORMAT_TEST_TEST_H_" + os.linesep + \
+        "#ifndef " + repo_root + "_WPIFORMAT_TEST_TEST_H_" + os.linesep + \
+        "#define " + repo_root + "_WPIFORMAT_TEST_TEST_H_" + os.linesep + \
         os.linesep + \
-        "#endif  // STYLEGUIDE_WPIFORMAT_TEST_TEST_H_" + os.linesep)
+        "#endif  // " + repo_root + "_WPIFORMAT_TEST_TEST_H_" + os.linesep)
     test.add_output(
-        "#ifndef STYLEGUIDE_TEST_H_" + os.linesep + \
-        "#define STYLEGUIDE_TEST_H_" + os.linesep + \
+        "#ifndef " + repo_root + "_TEST_H_" + os.linesep + \
+        "#define " + repo_root + "_TEST_H_" + os.linesep + \
         os.linesep + \
-        "#endif  // STYLEGUIDE_TEST_H_" + os.linesep, True, True)
+        "#endif  // " + repo_root + "_TEST_H_" + os.linesep, True, True)
 
     test.run(OutputType.FILE)

--- a/wpiformat/test/test_licenseupdate.py
+++ b/wpiformat/test/test_licenseupdate.py
@@ -27,7 +27,7 @@ class OpenTemporaryDirectory():
 def test_licenseupdate():
     year = str(date.today().year)
 
-    task = LicenseUpdate(year)
+    task = LicenseUpdate()
     test = TaskTest(task)
 
     file_appendix = \

--- a/wpiformat/wpiformat/__init__.py
+++ b/wpiformat/wpiformat/__init__.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 
 import argparse
-from datetime import date
 import math
 import multiprocessing as mp
 import os
@@ -236,13 +235,6 @@ def main():
         default=mp.cpu_count(),
         help="number of jobs to run (default is number of cores)")
     parser.add_argument(
-        "-y",
-        dest="year",
-        type=int,
-        default=date.today().year,
-        help=
-        "year to use when updating license headers (default is current year)")
-    parser.add_argument(
         "-clang",
         dest="clang_version",
         type=str,
@@ -352,7 +344,7 @@ def main():
         BraceComment(),
         CIdentList(),
         IncludeGuard(),
-        LicenseUpdate(str(args.year)),
+        LicenseUpdate(),
         JavaClass(),
         Newline(),
         Stdlib(),

--- a/wpiformat/wpiformat/cpplint.py
+++ b/wpiformat/wpiformat/cpplint.py
@@ -71,7 +71,7 @@ def IsSourceFile(filename):
   return _source_regex.search(filename)
 
 
-_USAGE = """
+_USAGE = r"""
 Syntax: cpplint.py [--repository=path]
                    [--headers=header_regex]
                    [--srcs=src_regex]

--- a/wpiformat/wpiformat/licenseupdate.py
+++ b/wpiformat/wpiformat/licenseupdate.py
@@ -1,5 +1,6 @@
 """This task updates the license header at the top of the file."""
 
+from datetime import date
 import os
 import regex
 import subprocess
@@ -10,16 +11,6 @@ from wpiformat.task import Task
 
 
 class LicenseUpdate(Task):
-
-    def __init__(self, current_year):
-        """Constructor for LicenseUpdate task.
-
-        Keyword arguments:
-        current_year -- year string
-        """
-        Task.__init__(self)
-
-        self.__current_year = current_year
 
     def should_process_file(self, config_file, name):
         license_regex = config_file.regex("licenseUpdateExclude")
@@ -150,7 +141,7 @@ class LicenseUpdate(Task):
         # If file hasn't been committed yet, use current calendar year as end of
         # copyright year range
         if last_year == "":
-            last_year = self.__current_year
+            last_year = str(date.today().year)
 
         success, first_year, appendix = self.__try_regex(
             lines, last_year, license_template)


### PR DESCRIPTION
With the new copyright year logic, the year override is almost never
used. When it is (for files which haven't yet been comitted, the current year
should be fine.