### PR TITLE
Fix file change detection

### DIFF
--- a/wpiformat/test/tasktest.py
+++ b/wpiformat/test/tasktest.py
@@ -82,17 +82,16 @@ class TaskTest:
                 print("Running test {}...".format(i))
 
                 if output_type == OutputType.FILE:
-                    output, file_changed, success = self.task.run_pipeline(
+                    output, success = self.task.run_pipeline(
                         config_file, self.inputs[i][0], self.inputs[i][1])
                 elif output_type == OutputType.STDOUT:
                     saved_stdout = sys.stdout
                     sys.stdout = io.StringIO()
-                    _output, file_changed, success = self.task.run_pipeline(
+                    _output, success = self.task.run_pipeline(
                         config_file, self.inputs[i][0], self.inputs[i][1])
                     sys.stdout.seek(0)
                     output = sys.stdout.read()
                     sys.stdout = saved_stdout
 
                 assert output == self.outputs[i][0]
-                assert file_changed == self.outputs[i][1]
                 assert success == self.outputs[i][2]

--- a/wpiformat/test/test_licenseupdate.py
+++ b/wpiformat/test/test_licenseupdate.py
@@ -244,30 +244,26 @@ def test_licenseupdate():
         # Run wpiformat on last-year.cpp
         with open("last-year.cpp", "r") as input:
             lines = input.read()
-        output, changed, success = task.run_pipeline(config_file,
-                                                     "last-year.cpp", lines)
+        output, success = task.run_pipeline(config_file, "last-year.cpp", lines)
         assert output == f"// Copyright (c) 2017-{int(year) - 1}\n\n"
 
         # Run wpiformat on this-year.cpp
         with open("last-year.cpp", "r") as input:
             lines = input.read()
-        output, changed, success = task.run_pipeline(config_file,
-                                                     "this-year.cpp", lines)
+        output, success = task.run_pipeline(config_file, "this-year.cpp", lines)
         assert output == f"// Copyright (c) 2017-{year}\n\n"
 
         # Run wpiformat on next-year.cpp
         with open("next-year.cpp", "r") as input:
             lines = input.read()
-        output, changed, success = task.run_pipeline(config_file,
-                                                     "next-year.cpp", lines)
+        output, success = task.run_pipeline(config_file, "next-year.cpp", lines)
         assert output == f"// Copyright (c) 2017-{int(year) + 1}\n\n"
 
         # Run wpiformat on no-year.cpp
         # Should have current calendar year
         with open("no-year.cpp", "r") as input:
             lines = input.read()
-        output, changed, success = task.run_pipeline(config_file, "no-year.cpp",
-                                                     lines)
+        output, success = task.run_pipeline(config_file, "no-year.cpp", lines)
         assert output == f"// Copyright (c) {year}\n\n"
 
     test.run(OutputType.FILE)

--- a/wpiformat/test/test_usingnamespacestd.py
+++ b/wpiformat/test/test_usingnamespacestd.py
@@ -7,7 +7,7 @@ from wpiformat.usingnamespacestd import UsingNamespaceStd
 def test_usingnamespacestd():
     test = TaskTest(UsingNamespaceStd())
 
-    warning_str = "avoid \"using namespace std;\" in production software. While it is used in introductory C++, it pollutes the global namespace with standard library symbols.\n"
+    warning_str = "avoid \"using namespace std;\" in production software. While it is used in introductory C++, it pollutes the global namespace with standard library symbols. Be more specific and use \"using std::thing;\" instead.\n"
 
     # Hello World
     test.add_input("./Main.cpp",

--- a/wpiformat/wpiformat/bracecomment.py
+++ b/wpiformat/wpiformat/bracecomment.py
@@ -84,7 +84,4 @@ class BraceComment(Task):
         if extract_location < len(lines):
             output += lines[extract_location:]
 
-        if output != lines:
-            return (output, True, True)
-        else:
-            return (lines, False, True)
+        return (output, True)

--- a/wpiformat/wpiformat/cidentlist.py
+++ b/wpiformat/wpiformat/cidentlist.py
@@ -17,7 +17,6 @@ class CIdentList(Task):
 
     def run_pipeline(self, config_file, name, lines):
         linesep = Task.get_linesep(lines)
-        file_changed = False
 
         output = ""
         pos = 0
@@ -115,7 +114,7 @@ class CIdentList(Task):
 
                 if len(extern_brace_indices) == 0:
                     self.__print_failure(name)
-                    return (lines, False, False)
+                    return (lines, False)
 
                 # If the next stack frame is from an extern without braces, pop
                 # it.
@@ -125,7 +124,7 @@ class CIdentList(Task):
             elif token == ";":
                 if len(extern_brace_indices) == 0:
                     self.__print_failure(name)
-                    return (lines, False, False)
+                    return (lines, False)
 
                 # If the next stack frame is from an extern without braces, pop
                 # it.
@@ -155,8 +154,6 @@ class CIdentList(Task):
                 output += lines[pos:match.span("paren")[0]] + "(void)"
                 pos = match.span("paren")[0] + len("()")
 
-                file_changed = True
-
         # Write rest of file if it wasn't all processed
         if pos < len(lines):
             output += lines[pos:]
@@ -166,7 +163,4 @@ class CIdentList(Task):
         if not success:
             self.__print_failure(name)
 
-        if file_changed:
-            return (output, file_changed, success)
-        else:
-            return (lines, file_changed, success)
+        return (output, success)

--- a/wpiformat/wpiformat/includeguard.py
+++ b/wpiformat/wpiformat/includeguard.py
@@ -62,14 +62,10 @@ class IncludeGuard(Task):
         if state == State.FINDING_IFNDEF:
             print("Error: " + name +
                   ": doesn't contain include guard or '#pragma once'")
-            return (lines, False, False)
+            return (lines, False)
 
         output = linesep.join(output_list).rstrip() + linesep
-
-        if output != lines:
-            return (output, True, True)
-        else:
-            return (lines, False, True)
+        return (output, True)
 
     def make_include_guard(self, config_file, name):
         """Returns properly formatted include guard based on repository root and

--- a/wpiformat/wpiformat/includeorder.py
+++ b/wpiformat/wpiformat/includeorder.py
@@ -375,7 +375,7 @@ class IncludeOrder(Task):
 
         # If header failed to classify, return failure
         if not valid_headers:
-            return (lines, False, False)
+            return (lines, False)
 
         if suboutput:
             output_list.extend(suboutput)
@@ -393,7 +393,4 @@ class IncludeOrder(Task):
         output_list.extend(lines_list[i:])
 
         output = self.linesep.join(output_list).rstrip() + self.linesep
-        if output != lines:
-            return (output, True, True)
-        else:
-            return (lines, False, True)
+        return (output, True)

--- a/wpiformat/wpiformat/javaclass.py
+++ b/wpiformat/wpiformat/javaclass.py
@@ -12,7 +12,6 @@ class JavaClass(Task):
 
     def run_pipeline(self, config_file, name, lines):
         linesep = Task.get_linesep(lines)
-        file_changed = False
 
         output = ""
         pos = 0
@@ -44,13 +43,8 @@ class JavaClass(Task):
                 output += lines[pos:match.span("extra")[0]]
                 pos = match.span()[1]
 
-                file_changed = True
-
         # Write rest of file if it wasn't all processed
         if pos < len(lines):
             output += lines[pos:]
 
-        if file_changed:
-            return (output, file_changed, True)
-        else:
-            return (lines, file_changed, True)
+        return (output, True)

--- a/wpiformat/wpiformat/jni.py
+++ b/wpiformat/wpiformat/jni.py
@@ -141,7 +141,7 @@ class Jni(Task):
         if pos < len(lines):
             output += lines[pos:]
 
-        if output == "" or output == lines:
-            return (lines, False, True)
+        if output == "":
+            return (lines, True)
         else:
-            return (output, True, True)
+            return (output, True)

--- a/wpiformat/wpiformat/licenseupdate.py
+++ b/wpiformat/wpiformat/licenseupdate.py
@@ -176,4 +176,4 @@ class LicenseUpdate(Task):
         # Copy rest of original file into new one
         output += appendix
 
-        return (output, lines != output, True)
+        return (output, True)

--- a/wpiformat/wpiformat/newline.py
+++ b/wpiformat/wpiformat/newline.py
@@ -6,9 +6,4 @@ from wpiformat.task import Task
 class Newline(Task):
 
     def run_pipeline(self, config_file, name, lines):
-        output = lines.rstrip() + Task.get_linesep(lines)
-
-        if output != lines:
-            return (output, True, True)
-        else:
-            return (lines, False, True)
+        return (lines.rstrip() + Task.get_linesep(lines), True)

--- a/wpiformat/wpiformat/task.py
+++ b/wpiformat/wpiformat/task.py
@@ -66,10 +66,10 @@ class Task:
         name -- file name string
         lines -- file contents string
 
-        Returns tuple containing processed lines, whether lines were changed,
-        and whether task succeeded in formatting the file.
+        Returns tuple containing processed lines and whether task succeeded in
+        processing the file.
         """
-        return ("", False, True)
+        return ("", True)
 
     @abstractmethod
     def run_batch(self, config_file, names):

--- a/wpiformat/wpiformat/usingdeclaration.py
+++ b/wpiformat/wpiformat/usingdeclaration.py
@@ -71,4 +71,4 @@ class UsingDeclaration(Task):
                         print(name + ": " + str(linenum) + ": '" + token + \
                               "' in global namespace")
 
-        return (lines, False, format_succeeded)
+        return (lines, format_succeeded)

--- a/wpiformat/wpiformat/usingnamespacestd.py
+++ b/wpiformat/wpiformat/usingnamespacestd.py
@@ -25,4 +25,4 @@ class UsingNamespaceStd(Task):
                 ": avoid \"using namespace std;\" in production software. While it is used in introductory C++, it pollutes the global namespace with standard library symbols. Be more specific and use \"using std::thing;\" instead."
             )
 
-        return (lines, False, True)
+        return (lines, True)

--- a/wpiformat/wpiformat/whitespace.py
+++ b/wpiformat/wpiformat/whitespace.py
@@ -10,13 +10,10 @@ class Whitespace(Task):
     def run_pipeline(self, config_file, name, lines):
         linesep = Task.get_linesep(lines)
 
-        file_changed = False
         output = ""
 
         for line in lines.splitlines():
             processed_line = line[0:len(line)].rstrip()
-            if not file_changed and len(line) != len(processed_line):
-                file_changed = True
             output += processed_line + linesep
 
-        return (output, file_changed, True)
+        return (output, True)


### PR DESCRIPTION
Previously, a file was considered changed and rewritten if any file in a
pipeline changed it. Now, it's only considered changed if the input to
the pipeline doesn't equal the output. This allows tasks later in the
pipeline to fix the output of previous tasks.

To make this work across more scenarios, clang-format had to be changed
to run on a per-file basis instead of batched. This results in an
increase in processing time due to process creation overhead.