### PR TITLE
Pin dependency versions

### DIFF
--- a/wpiformat/setup.py
+++ b/wpiformat/setup.py
@@ -70,7 +70,7 @@ setup(
     zip_safe=True,
     setup_requires=["pytest-runner"],
     tests_require=["pytest"],
-    install_requires=["regex", "yapf"],
+    install_requires=["regex==2019.08.19", "yapf==0.29.0"],
     license="BSD License",
     classifiers=[
         "Development Status :: 5 - Production/Stable",


### PR DESCRIPTION
Later versions of the regex package don't install on Azure CI due to
failures with easy_install.