### PR TITLE
Bump copyright year if a file has uncommitted changes

### DIFF
--- a/wpiformat/wpiformat/licenseupdate.py
+++ b/wpiformat/wpiformat/licenseupdate.py
@@ -140,9 +140,13 @@ class LicenseUpdate(Task):
         last_year = subprocess.run(cmd,
                                    stdout=subprocess.PIPE).stdout.decode()[:4]
 
-        # If file hasn't been committed yet, use current calendar year as end of
-        # copyright year range
-        if last_year == "":
+        # Check if file has uncomitted changes in the working directory
+        cmd = ["git", "diff-index", "--quiet", "HEAD", "--", name]
+        has_uncommitted_changes = subprocess.run(cmd).returncode
+
+        # If file hasn't been committed yet or has changes in the working
+        # directory, use current calendar year as end of copyright year range
+        if last_year == "" or has_uncommitted_changes:
             last_year = str(date.today().year)
 
         success, first_year, appendix = self.__try_regex(

--- a/wpiformat/wpiformat/test/test_licenseupdate.py
+++ b/wpiformat/wpiformat/test/test_licenseupdate.py
@@ -247,6 +247,18 @@ def test_licenseupdate():
         output, success = task.run_pipeline(config_file, "last-year.cpp", lines)
         assert output == f"// Copyright (c) 2017-{int(year) - 1}\n\n"
 
+        # Run wpiformat on last-year.cpp with uncommitted changes. It should
+        # update to next year instead of keeping previous year
+        with open("last-year.cpp", "a") as input:
+            input.write("change\n")
+        output, success = task.run_pipeline(config_file, "last-year.cpp",
+                                            lines + "change\n")
+        assert output == f"// Copyright (c) 2017-{year}\n\nchange\n"
+
+        # Erase changes made to last-year.cpp in previous test
+        with open("last-year.cpp", "w") as input:
+            input.write(lines)
+
         # Run wpiformat on this-year.cpp
         with open("last-year.cpp", "r") as input:
             lines = input.read()


### PR DESCRIPTION
This obviates needing to rerun wpiformat after a commit if the file had
a previous copyright year and the new commit is done in a later year.

If the file is being amended into a commit with a date from a previous
year such that the old year is kept, the year set by uncommitted changes
will be incorrect and will require rerunning wpiformat as before. This
was already necessary so this patch is strictly an improvement.