### PR TITLE
Print config filename in double verbose mode

### DIFF
--- a/wpiformat/wpiformat/__init__.py
+++ b/wpiformat/wpiformat/__init__.py
@@ -89,6 +89,7 @@ def proc_pipeline(name):
         with print_lock:
             print("Processing", name)
             if verbose2:
+                print("  with config " + config_file.file_name)
                 for subtask in task_pipeline:
                     if subtask.should_process_file(config_file, name):
                         print("  with " + type(subtask).__name__)

--- a/wpiformat/wpiformat/config.py
+++ b/wpiformat/wpiformat/config.py
@@ -32,14 +32,17 @@ class Config:
         directory -- current directory from which to start search
         file_name -- file name string
 
-        Returns list containing file contents or triggers program exit.
+        Returns tuple of file name and list containing file contents or triggers
+        program exit.
         """
         file_found = False
         while not file_found:
             try:
                 with open(directory + os.sep + file_name, "r") as file_contents:
                     file_found = True
-                    return file_contents.read().splitlines()
+                    return os.path.join(
+                        directory,
+                        file_name), file_contents.read().splitlines()
             except OSError:
                 # .git files are ignored, which are created within submodules
                 if os.path.isdir(directory + os.sep + ".git"):
@@ -175,7 +178,7 @@ class Config:
         group_name = ""
         group_elements = []
 
-        lines = self.read_file(directory, file_name)
+        self.file_name, lines = self.read_file(directory, file_name)
         if not lines:
             return None
 

--- a/wpiformat/wpiformat/licenseupdate.py
+++ b/wpiformat/wpiformat/licenseupdate.py
@@ -128,7 +128,7 @@ class LicenseUpdate(Task):
     def run_pipeline(self, config_file, name, lines):
         linesep = super().get_linesep(lines)
 
-        license_template = Config.read_file(
+        _, license_template = Config.read_file(
             os.path.dirname(os.path.abspath(name)), ".styleguide-license")
 
         # Get year when file was most recently modified in Git history


### PR DESCRIPTION
This lets the user see which config applies to which file to aid them in
debugging filename pattern matches.