### PR TITLE
Replace some subprocess.run() calls with subprocess.check_output()

### DIFF
--- a/wpiformat/README.rst
+++ b/wpiformat/README.rst
@@ -6,7 +6,7 @@ Provides linters and formatters for ensuring WPILib's C++, Java, and Python code
 Dependencies
 ************
 
-- `Python 3.5 or newer <https://www.python.org/downloads/>`_
+- `Python 3.6 or newer <https://www.python.org/downloads/>`_
 - clang-format (included with `LLVM <http://llvm.org/releases/download.html>`_)
 
 To obtain newer versions of clang-format on older Debian and Ubuntu releases, either upgrade to one that does or add the appropriate ``deb ... main`` line from `apt.llvm.org <http://apt.llvm.org/>`_ to ``/etc/apt/sources.list``. Then install ``clang-format-#`` where ``#`` is the version number.

--- a/wpiformat/wpiformat/licenseupdate.py
+++ b/wpiformat/wpiformat/licenseupdate.py
@@ -137,13 +137,12 @@ class LicenseUpdate(Task):
         # log" because the year the file was last modified in the history should
         # be used. Author dates can be older than this or even out of order in
         # the log.
-        cmd = ["git", "log", "-n", "1", "--format=%ci", "--", name]
-        last_year = subprocess.run(cmd,
-                                   stdout=subprocess.PIPE).stdout.decode()[:4]
+        last_year = subprocess.check_output(
+            ["git", "log", "-n", "1", "--format=%ci", "--", name]).decode()[:4]
 
         # Check if file has uncomitted changes in the working directory
-        cmd = ["git", "diff-index", "--quiet", "HEAD", "--", name]
-        has_uncommitted_changes = subprocess.run(cmd).returncode
+        has_uncommitted_changes = subprocess.run(
+            ["git", "diff-index", "--quiet", "HEAD", "--", name]).returncode
 
         # If file hasn't been committed yet or has changes in the working
         # directory, use current calendar year as end of copyright year range


### PR DESCRIPTION
wpiformat calls "git diff --name-only master" in a subprocess to get a
list of files which have been modified from master. In GitHub Actions,
there is no master branch by default. When wpiformat is run in GitHub
Actions, this causes the git subprocess to fail. subprocess.run()
doesn't check the status code, so wpiformat was reporting success when
the program had actually failed with an error.

subprocess.check_output() does check the return code by default, and
it's simpler than the original code because it returns stdout directly
without requiring any PIPE flags.