### PR TITLE
Limit number of parallel jobs to 60

### DIFF
--- a/wpiformat/wpiformat/__init__.py
+++ b/wpiformat/wpiformat/__init__.py
@@ -228,9 +228,7 @@ def main():
     )
     # mp uses a few internal events, and windows cannot wait on more then 64 events at once
     # Therefore, on a 64 thread system you can't use 64 threads.
-    cpu_count = mp.cpu_count()
-    if cpu_count > 60:
-        cpu_count = 60
+    cpu_count = min(60, mp.cpu_count())
     parser.add_argument(
         "-j",
         dest="jobs",

--- a/wpiformat/wpiformat/__init__.py
+++ b/wpiformat/wpiformat/__init__.py
@@ -226,8 +226,10 @@ def main():
         help=
         "verbosity level 2 (prints names of processed files and tasks run on them)"
     )
-    # mp uses a few internal events, and windows cannot wait on more then 64 events at once
-    # Therefore, on a 64 thread system you can't use 64 threads.
+    # mp.Pool() uses WaitForMultipleObjects() to wait for subprocess completion
+    # on Windows. WaitForMultipleObjects() cannot wait on more then 64 events at
+    # once, and mp uses a few internal events. Therefore, the maximum number of
+    # parallel jobs is 60.
     cpu_count = min(60, mp.cpu_count())
     parser.add_argument(
         "-j",

--- a/wpiformat/wpiformat/__init__.py
+++ b/wpiformat/wpiformat/__init__.py
@@ -226,11 +226,16 @@ def main():
         help=
         "verbosity level 2 (prints names of processed files and tasks run on them)"
     )
+    # mp uses a few internal events, and windows cannot wait on more then 64 events at once
+    # Therefore, on a 64 thread system you can't use 64 threads.
+    cpu_count = mp.cpu_count()
+    if cpu_count > 60:
+        cpu_count = 60
     parser.add_argument(
         "-j",
         dest="jobs",
         type=int,
-        default=mp.cpu_count(),
+        default=cpu_count,
         help="number of jobs to run (default is number of cores)")
     parser.add_argument(
         "-clang",


### PR DESCRIPTION
Windows can't wait on more then 64 handles. MP internally waits on a few, so add 64 jobs and the internal few, and windows errors