### PR TITLE
Fix incorrect linting for constexpr if

### DIFF
--- a/wpiformat/wpiformat/cpplint.py
+++ b/wpiformat/wpiformat/cpplint.py
@@ -2248,8 +2248,8 @@ def CheckBraces(filename, clean_lines, linenum, error):
 
   # If braces come on one side of an else, they should be on both.
   # However, we have to worry about "else if" that spans multiple lines!
-  if Search(r'else if\s*\(', line):       # could be multi-line if
-    brace_on_left = bool(Search(r'}\s*else if\s*\(', line))
+  if Search(r'else if(\s+constexpr)?\s*\(', line):  # could be multi-line if
+    brace_on_left = bool(Search(r'}\s*else if(\s+constexpr)?\s*\(', line))
     # find the ( after the if
     pos = line.find('else if')
     pos = line.find('(', pos)


### PR DESCRIPTION
cpplint.py didn't know about constexpr if, so the brace linting reports
false positives for them.

```
/home/runner/work/allwpilib/allwpilib/wpilibc/src/main/native/cpp/DriverStation.cpp:49: If an else has a brace on one side, it should have it on both [readability/braces] [5]
```

Adding an optional group for "constexpr" fixes the linting.