### PR TITLE
Ensure test assertions are run for excluded files

### DIFF
--- a/.styleguide
+++ b/.styleguide
@@ -1,5 +1,6 @@
 cppHeaderFileInclude {
   \.h$
+  \.hpp$
   \.inc$
 }
 

--- a/wpiformat/wpiformat/test/tasktest.py
+++ b/wpiformat/wpiformat/test/tasktest.py
@@ -92,6 +92,9 @@ class TaskTest:
                     sys.stdout.seek(0)
                     output = sys.stdout.read()
                     sys.stdout = saved_stdout
+            else:
+                output = self.inputs[i][1]
+                success = True
 
-                assert output == self.outputs[i][0]
-                assert success == self.outputs[i][2]
+            assert output == self.outputs[i][0]
+            assert success == self.outputs[i][2]

--- a/wpiformat/wpiformat/test/test_includeorder.py
+++ b/wpiformat/wpiformat/test/test_includeorder.py
@@ -536,7 +536,7 @@ def test_includeorder():
 
     # Ensure lines containing #include that aren't includes are not processed
     test.add_input("./Test.h", "// #included here" + os.linesep)
-    test.add_output("// #included here" + os.linesep, False, True)
+    test.add_latest_input_as_output(True)
 
     # Ensure extra newline isn't inserted between #pragma and #ifdef
     test.add_input("./Test.h",

--- a/wpiformat/wpiformat/test/test_licenseupdate.py
+++ b/wpiformat/wpiformat/test/test_licenseupdate.py
@@ -173,9 +173,7 @@ def test_licenseupdate():
         "./Excluded.h",
         "/* Copyright (c) Company Name 2011-{}. */".format(year) + os.linesep +
         os.linesep + file_appendix)
-    test.add_output(
-        "/* Copyright (c) Company Name 2011-{}. */".format(year) + os.linesep +
-        os.linesep + file_appendix, False, True)
+    test.add_latest_input_as_output(True)
 
     # Ensure license regex matches
     test.add_input("./Test.h",


### PR DESCRIPTION
Previously, if a file was excluded, the test's output wouldn't be
checked. This uncovered a missing C++ header extension used by the
cidentlist tests.