### PR TITLE
Add options to run clang-tidy

### DIFF
--- a/wpiformat/wpiformat/__init__.py
+++ b/wpiformat/wpiformat/__init__.py
@@ -296,7 +296,9 @@ def main():
         "-tidy",
         dest="tidy",
         action="store_true",
-        help="also runs clang-tidy-CLANG_VERSION; this requires a compile_commands.json file")
+        help=
+        "also runs clang-tidy-CLANG_VERSION; this requires a compile_commands.json file"
+    )
     parser.add_argument(
         "-compile-commands",
         dest="compile_commands",
@@ -448,6 +450,7 @@ def main():
     if args.tidy:
         task_pipeline = [ClangTidy(args.clang_version, args.compile_commands)]
         run_standalone(task_pipeline, args, files)
+
 
 if __name__ == "__main__":
     main()

--- a/wpiformat/wpiformat/__init__.py
+++ b/wpiformat/wpiformat/__init__.py
@@ -10,6 +10,7 @@ import sys
 from wpiformat.bracecomment import BraceComment
 from wpiformat.cidentlist import CIdentList
 from wpiformat.clangformat import ClangFormat
+from wpiformat.clangtidy import ClangTidy
 from wpiformat.config import Config
 from wpiformat.eofnewline import EofNewline
 from wpiformat.includeguard import IncludeGuard
@@ -118,6 +119,31 @@ def proc_pipeline(name):
     return all_success
 
 
+def proc_standalone(name):
+    """Runs each task on each file.
+
+    Keyword arguments:
+    name -- file name string
+    """
+    config_file = Config(os.path.dirname(name), ".styleguide")
+    if verbose2:
+        with print_lock:
+            print("Processing", name)
+            for subtask in task_pipeline:
+                if subtask.should_process_file(config_file, name):
+                    print("  with " + type(subtask).__name__)
+
+    # The success flag is aggregated across multiple file processing results
+    all_success = True
+
+    for subtask in task_pipeline:
+        if subtask.should_process_file(config_file, name):
+            success = subtask.run_standalone(config_file, name)
+            all_success &= success
+
+    return all_success
+
+
 def chunks(l, max_len):
     """Yield successive chunks from l whose content lengths sum to less than
     max_len.
@@ -190,6 +216,26 @@ def run_pipeline(task_pipeline, args, files):
             sys.exit(1)
 
 
+def run_standalone(task_pipeline, args, files):
+    """Spawns process pool for proc_standalone().
+
+    Keyword arguments:
+    task_pipeline -- task pipeline
+    args -- command line arguments from argparse
+    files -- list of file names to process
+
+    Calls sys.exit(1) if any task fails.
+    """
+    init_args = (task_pipeline, args.verbose1, args.verbose2)
+
+    with mp.Pool(args.jobs, proc_init, init_args) as pool:
+        # Start worker processes for task pipeline
+        results = pool.map(proc_standalone, files)
+
+        if not all(results):
+            sys.exit(1)
+
+
 def run_batch(task_pipeline, args, file_batches):
     """Spawns process pool for proc_batch().
 
@@ -245,6 +291,19 @@ def main():
         default="",
         help=
         "version suffix for clang-format (invokes \"clang-format-CLANG_VERSION\" or \"clang-format\" if no suffix provided)"
+    )
+    parser.add_argument(
+        "-tidy",
+        dest="tidy",
+        action="store_true",
+        help="also runs clang-tidy-CLANG_VERSION; this requires a compile_commands.json file")
+    parser.add_argument(
+        "-compile-commands",
+        dest="compile_commands",
+        type=str,
+        default="",
+        help=
+        "path to directory containing compile_commands.json; if unset will search in parent paths"
     )
     parser.add_argument(
         "-f",
@@ -385,6 +444,10 @@ def main():
     task_pipeline = [PyFormat(), Lint()]
     run_batch(task_pipeline, args, file_batches)
 
+    # ClangTidy is run last of all; it needs the actual files
+    if args.tidy:
+        task_pipeline = [ClangTidy(args.clang_version, args.compile_commands)]
+        run_standalone(task_pipeline, args, files)
 
 if __name__ == "__main__":
     main()

--- a/wpiformat/wpiformat/__init__.py
+++ b/wpiformat/wpiformat/__init__.py
@@ -294,14 +294,14 @@ def main():
     )
     parser.add_argument(
         "-tidy-changed",
-        dest="tidy-changed",
+        dest="tidy_changed",
         action="store_true",
         help=
         "also runs clang-tidy-CLANG_VERSION on changed files; this requires a compile_commands.json file"
     )
     parser.add_argument(
         "-tidy-all",
-        dest="tidy-all",
+        dest="tidy_all",
         action="store_true",
         help=
         "also runs clang-tidy-CLANG_VERSION on all files (this takes a while); this requires a compile_commands.json file"

--- a/wpiformat/wpiformat/__init__.py
+++ b/wpiformat/wpiformat/__init__.py
@@ -293,11 +293,18 @@ def main():
         "version suffix for clang-format (invokes \"clang-format-CLANG_VERSION\" or \"clang-format\" if no suffix provided)"
     )
     parser.add_argument(
-        "-tidy",
-        dest="tidy",
+        "-tidy-changed",
+        dest="tidy-changed",
         action="store_true",
         help=
-        "also runs clang-tidy-CLANG_VERSION; this requires a compile_commands.json file"
+        "also runs clang-tidy-CLANG_VERSION on changed files; this requires a compile_commands.json file"
+    )
+    parser.add_argument(
+        "-tidy-all",
+        dest="tidy-all",
+        action="store_true",
+        help=
+        "also runs clang-tidy-CLANG_VERSION on all files (this takes a while); this requires a compile_commands.json file"
     )
     parser.add_argument(
         "-compile-commands",
@@ -447,7 +454,9 @@ def main():
     run_batch(task_pipeline, args, file_batches)
 
     # ClangTidy is run last of all; it needs the actual files
-    if args.tidy:
+    if args.tidy_all or args.tidy_changed:
+        if args.tidy_changed:
+            files = list(set(files) & set(changed_file_list))
         task_pipeline = [ClangTidy(args.clang_version, args.compile_commands)]
         run_standalone(task_pipeline, args, files)
 

--- a/wpiformat/wpiformat/__init__.py
+++ b/wpiformat/wpiformat/__init__.py
@@ -292,14 +292,15 @@ def main():
         help=
         "version suffix for clang-format (invokes \"clang-format-CLANG_VERSION\" or \"clang-format\" if no suffix provided)"
     )
-    parser.add_argument(
+    tidy_group = parser.add_mutually_exclusive_group()
+    tidy_group.add_argument(
         "-tidy-changed",
         dest="tidy_changed",
         action="store_true",
         help=
         "also runs clang-tidy-CLANG_VERSION on changed files; this requires a compile_commands.json file"
     )
-    parser.add_argument(
+    tidy_group.add_argument(
         "-tidy-all",
         dest="tidy_all",
         action="store_true",

--- a/wpiformat/wpiformat/clangtidy.py
+++ b/wpiformat/wpiformat/clangtidy.py
@@ -1,0 +1,57 @@
+"""This task runs clang-tidy on the file."""
+
+from subprocess import Popen, PIPE
+import sys
+
+from wpiformat.task import Task
+
+
+class ClangTidy(Task):
+
+    def __init__(self, clang_version, compile_commands):
+        """Constructor for ClangTidy task.
+
+        Keyword arguments:
+        clang_version -- version number of clang-tidy appended to executable
+                         name
+        compile_commands -- directory containing compile_commands.json
+        """
+        super().__init__()
+
+        if clang_version == "":
+            self.exec_name = "clang-tidy"
+        else:
+            self.exec_name = "clang-tidy-" + clang_version
+
+        self.args = ["--quiet"]
+        if compile_commands:
+            self.args += ["-p", compile_commands]
+
+    @staticmethod
+    def should_process_file(config_file, name):
+        return config_file.is_cpp_file(name)
+
+    def run_standalone(self, config_file, name):
+        try:
+            p = Popen([self.exec_name] + self.args + [name],
+                      encoding="utf-8",
+                      stdout=PIPE,
+                      stderr=PIPE)
+            output = p.communicate()[0]
+        except FileNotFoundError:
+            print("Error: " + self.exec_name +
+                  " not found in PATH. Is it installed?",
+                  file=sys.stderr)
+            return False
+
+        lines = [l for l in output.split('\n') if l]
+
+        # ignore include file not found errors at beginning
+        if lines and "file not found [clang-diagnostic-error]" in lines[0]:
+            lines = lines[3:]
+
+        if lines:
+            print("== clang-tidy " + name + " ==")
+            print('\n'.join(lines))
+
+        return True


### PR DESCRIPTION
Adds -tidy-all and -tidy-changed options to run clang-tidy on all or only changed files, respectively.
Also adds -compile-commands argument to set location of compile_commands.json.

Fixes #197.