### PR TITLE
Lock regex version to 2021.08.21

### DIFF
--- a/wpiformat/setup.py
+++ b/wpiformat/setup.py
@@ -70,7 +70,7 @@ setup(
     zip_safe=True,
     setup_requires=["pytest-runner"],
     tests_require=["pytest"],
-    install_requires=["regex", "yapf==0.31.0"],
+    install_requires=["regex==2021.08.21", "yapf==0.31.0"],
     license="BSD License",
     classifiers=[
         "Development Status :: 5 - Production/Stable",


### PR DESCRIPTION
The published package for 2021.08.27 hangs on exit in multiprocessing
and threading waiting on I/O. I was able to reproduce this locally with
2021.08.27, and 2021.08.21 didn't exhibit the issue.

I also tried installing local builds of the regex git repo for the
commits on 8/21 and 8/27; they both worked fine. The issue appears to be
unique to the published package for 2021.08.27.