### PR TITLE
Fix clang-tidy exception "TypeError: 'list' object is not an iterator"

### DIFF
--- a/wpiformat/wpiformat/clangtidy.py
+++ b/wpiformat/wpiformat/clangtidy.py
@@ -53,11 +53,12 @@ class ClangTidy(Task):
 
         # Ignore include file not found errors
         filtered_lines = []
-        for l in lines:
+        iterlines = iter(lines)
+        for l in iterlines:
             if "file not found [clang-diagnostic-error]" in l:
                 # Skip #include line and caret indicator line
-                next(lines)
-                next(lines)
+                next(iterlines)
+                next(iterlines)
             else:
                 filtered_lines.append(l)
         lines = filtered_lines


### PR DESCRIPTION
This is the backtrace.
```
Processing /home/runner/work/sysid/sysid/sysid-projects/mechanism/src/main/cpp/Robot.cpp
  with ClangTidy
multiprocessing.pool.RemoteTraceback:
"""
Traceback (most recent call last):
  File "/opt/hostedtoolcache/Python/3.8.11/x64/lib/python3.8/multiprocessing/pool.py", line 125, in worker
    result = (True, func(*args, **kwds))
  File "/opt/hostedtoolcache/Python/3.8.11/x64/lib/python3.8/multiprocessing/pool.py", line 48, in mapstar
    return list(map(*args))
  File "/opt/hostedtoolcache/Python/3.8.11/x64/lib/python3.8/site-packages/wpiformat/__init__.py", line 142, in proc_standalone
    success = subtask.run_standalone(config_file, name)
  File "/opt/hostedtoolcache/Python/3.8.11/x64/lib/python3.8/site-packages/wpiformat/clangtidy.py", line 59, in run_standalone
    next(lines)
TypeError: 'list' object is not an iterator
"""

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/opt/hostedtoolcache/Python/3.8.11/x64/bin/wpiformat", line 8, in <module>
    sys.exit(main())
  File "/opt/hostedtoolcache/Python/3.8.11/x64/lib/python3.8/site-packages/wpiformat/__init__.py", line 501, in main
    run_standalone(task_pipeline, args, files)
  File "/opt/hostedtoolcache/Python/3.8.11/x64/lib/python3.8/site-packages/wpiformat/__init__.py", line 234, in run_standalone
    results = pool.map(proc_standalone, files)
  File "/opt/hostedtoolcache/Python/3.8.11/x64/lib/python3.8/multiprocessing/pool.py", line 364, in map
    return self._map_async(func, iterable, mapstar, chunksize).get()
  File "/opt/hostedtoolcache/Python/3.8.11/x64/lib/python3.8/multiprocessing/pool.py", line 771, in get
    raise self._value
TypeError: 'list' object is not an iterator
```