### PR TITLE
Support stdlib NOLINT comment on functions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-latest, windows-latest, ubuntu-latest]
-        python-version: [3.6, 3.7, 3.8]
+        python-version: ['3.8', '3.9', '3.10']
     name: Test - ${{ matrix.os }}, ${{ matrix.python-version }}
     runs-on: ${{ matrix.os }}
     steps:
@@ -136,7 +136,7 @@ jobs:
 
       - uses: actions/setup-python@v2
         with:
-          python-version: 3.7
+          python-version: '3.10'
 
       - name: Install Python dependencies
         run: pip install wheel

--- a/wpiformat/wpiformat/stdlib.py
+++ b/wpiformat/wpiformat/stdlib.py
@@ -223,7 +223,8 @@ class Stdlib(Task):
             pos = match.start(1) + len(header.prefix) + len(match.group(1))
 
             # If function name is part of this header, substitute its name
-            if match.group(1) in header.func_names:
+            line = lines[match.start(1):lines.find("\n", match.start(1))]
+            if match.group(1) in header.func_names and "NOLINT" not in line:
                 lines = lines[0:match.start(1)] + header.prefix + \
                     match.group(1) + lines[match.end(1):]
         return lines

--- a/wpiformat/wpiformat/test/test_stdlib.py
+++ b/wpiformat/wpiformat/test/test_stdlib.py
@@ -36,11 +36,21 @@ def test_stdlib():
         "  std::free(mem);" + os.linesep + \
         "}" + os.linesep, True)
 
-    # Test NOLINT
+    # Test NOLINT on #include
     test.add_input("./Main.cpp",
         "#include <cstdint>  // NOLINT" + os.linesep + \
         "#include <stdlib.h>  // NOLINT" + os.linesep)
     test.add_latest_input_as_output(True)
+
+    # Test NOLINT on function
+    test.add_input("./Main.cpp",
+        "  abs()  // NOLINT" + os.linesep + \
+        "  abs()" + os.linesep + \
+        "  abs()  // NOLINT" + os.linesep)
+    test.add_output(
+        "  abs()  // NOLINT" + os.linesep + \
+        "  std::abs()" + os.linesep + \
+        "  abs()  // NOLINT" + os.linesep, True)
 
     # FILE should be recognized as type here
     test.add_input("./Class.cpp", "static FILE* Class::file = nullptr;")


### PR DESCRIPTION
Autodifferentiation libraries use ADL to overload functions from
`<cmath>`, and stdlib.py breaks calls to those by adding the std:: prefix.