### PR TITLE
Make clang-tidy output use one print() call

### DIFF
--- a/wpiformat/wpiformat/clangtidy.py
+++ b/wpiformat/wpiformat/clangtidy.py
@@ -66,8 +66,7 @@ class ClangTidy(Task):
         lines = filtered_lines
 
         if lines:
-            print("== clang-tidy " + name + " ==")
-            print("\n".join(lines))
+            print(f"== clang-tidy {name} ==\n" + "\n".join(lines))
             return False
 
         return True


### PR DESCRIPTION
This helps avoid interleaved output.