### PR TITLE
Add argument for clang-tidy extra arguments

### DIFF
--- a/wpiformat/wpiformat/__init__.py
+++ b/wpiformat/wpiformat/__init__.py
@@ -328,6 +328,13 @@ def main():
         help="path to directory containing compile_commands.json; if unset will search in parent paths",
     )
     parser.add_argument(
+        "-tidy-extra-args",
+        dest="tidy_extra_args",
+        type=str,
+        default="",
+        help='a comma-delimited list of extra arguments for clang-tidy (given "ARG1,ARG2", invokes "clang-tidy -extra-arg -ARG1 -extra-arg -ARG2")',
+    )
+    parser.add_argument(
         "-f",
         dest="file",
         type=str,
@@ -493,7 +500,13 @@ def main():
     if args.tidy_all or args.tidy_changed:
         if args.tidy_changed:
             files = list(set(files) & set(changed_file_list))
-        task_pipeline = [ClangTidy(args.clang_version, args.compile_commands)]
+        task_pipeline = [
+            ClangTidy(
+                args.clang_version,
+                args.compile_commands,
+                args.tidy_extra_args.split(","),
+            )
+        ]
         run_standalone(task_pipeline, args, files)
 
 

--- a/wpiformat/wpiformat/clangtidy.py
+++ b/wpiformat/wpiformat/clangtidy.py
@@ -7,13 +7,14 @@ from wpiformat.task import Task
 
 
 class ClangTidy(Task):
-    def __init__(self, clang_version, compile_commands):
+    def __init__(self, clang_version, compile_commands, extra_args):
         """Constructor for ClangTidy task.
 
         Keyword arguments:
         clang_version -- version number of clang-tidy appended to executable
                          name
         compile_commands -- directory containing compile_commands.json
+        extra_args -- list of extra arguments to clang-tidy
         """
         super().__init__()
 
@@ -25,6 +26,12 @@ class ClangTidy(Task):
         self.args = ["--quiet"]
         if compile_commands:
             self.args += ["-p", compile_commands]
+
+        # Prepend a dash to the argument here because the main argument parser
+        # treats strings with a dash prefix as a new argument instead of the
+        # value for -extra-args
+        for arg in extra_args:
+            self.args += ["-extra-arg", "-" + arg]
 
     @staticmethod
     def should_process_file(config_file, name):


### PR DESCRIPTION
This is useful for overriding the standard version of C++ files that aren't listed in the compile_commands.json (e.g., headers).