### PR TITLE
Fix clang-tidy with no extra args

### DIFF
--- a/wpiformat/wpiformat/__init__.py
+++ b/wpiformat/wpiformat/__init__.py
@@ -504,7 +504,7 @@ def main():
             ClangTidy(
                 args.clang_version,
                 args.compile_commands,
-                args.tidy_extra_args.split(","),
+                args.tidy_extra_args.split(",") if args.tidy_extra_args else [],
             )
         ]
         run_standalone(task_pipeline, args, files)


### PR DESCRIPTION
Previously, when no extra arguments were provided, ClangTidy would be given a list with one element (the empty string). Now, an empty list is given.