### PR TITLE
Disable macOS CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-11, windows-2022, ubuntu-22.04]
+        # macos-11 removed because brew no longer has clang-format@15 and below
+        # os: [macos-11, windows-2022, ubuntu-22.04]
+        os: [windows-2022, ubuntu-22.04]
         python-version: ['3.8', '3.9', '3.10']
     name: Test - ${{ matrix.os }}, ${{ matrix.python-version }}
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
brew no longer supports clang-format below 16; we use 14.