### PR TITLE
Revert clang-tidy changes and print stderr on clang-format error

### DIFF
--- a/wpiformat/wpiformat/clangformat.py
+++ b/wpiformat/wpiformat/clangformat.py
@@ -35,13 +35,14 @@ class ClangFormat(Task):
                 stdout=PIPE,
                 encoding="utf-8",
             )
-            output = p.communicate(input=lines)[0]
+            stdout, stderr = p.communicate(input=lines)
 
             if p.returncode != 0:
                 print(
                     f"error: {self.exec_name} returned non-zero exit status {p.returncode}",
                     file=sys.stderr,
                 )
+                print(stderr, file=sys.stderr)
                 return lines, False
         except FileNotFoundError:
             print(
@@ -50,4 +51,4 @@ class ClangFormat(Task):
             )
             return lines, False
 
-        return output, True
+        return stdout, True

--- a/wpiformat/wpiformat/clangtidy.py
+++ b/wpiformat/wpiformat/clangtidy.py
@@ -41,17 +41,13 @@ class ClangTidy(Task):
 
     def run_standalone(self, config_file, name):
         try:
-            output = subprocess.check_output(
+            stdout = subprocess.run(
                 [self.exec_name] + self.args + [name],
+                stdout=subprocess.PIPE,
                 stderr=subprocess.STDOUT,
                 encoding="utf-8",
-            )
-        except subprocess.CalledProcessError as e:
-            print(
-                f"error: {self.exec_name} returned non-zero exit status {e.returncode}",
-                file=sys.stderr,
-            )
-            return False
+                check=False,
+            ).stdout
         except FileNotFoundError:
             print(
                 f"error: {self.exec_name} not found in PATH. Is it installed?",
@@ -59,7 +55,7 @@ class ClangTidy(Task):
             )
             return False
 
-        lines = [l for l in output.rstrip().split("\n") if l]
+        lines = [l for l in stdout.rstrip().split("\n") if l]
 
         # Filter out "X error(s) and Y warning(s) generated." lines
         lines = [l for l in lines if " generated." not in l]


### PR DESCRIPTION
clang-tidy returns 1 if it detects any errors, so we shouldn't kill processing in that case. Note that the clang-format return code changes were left intact.