### PR TITLE
Don't error on unknown NOLINT categories

### DIFF
--- a/wpiformat/wpiformat/cpplint.py
+++ b/wpiformat/wpiformat/cpplint.py
@@ -312,9 +312,6 @@ def ParseNolintSuppressions(filename, raw_line, linenum, error):
         category = category[1:-1]
         if category in _ERROR_CATEGORIES:
           _error_suppressions.setdefault(category, set()).add(suppressed_line)
-        else:
-          error(filename, linenum, 'readability/nolint', 5,
-                'Unknown NOLINT error category: %s' % category)
 
 
 def ProcessGlobalSuppresions(lines):


### PR DESCRIPTION
clang-tidy has a lot of lint categories that cpplint doesn't know about.