### PR TITLE
[wpiformat] Make changed file list ignore upstream changes

### DIFF
--- a/wpiformat/wpiformat/__init__.py
+++ b/wpiformat/wpiformat/__init__.py
@@ -436,7 +436,7 @@ def main():
 
     # Create list of all changed files
     output_list = subprocess.check_output(
-        ["git", "diff", "--name-only", main_branch], encoding="ascii"
+        ["git", "diff", "--name-only", f"{main_branch}..."], encoding="ascii"
     ).split()
     changed_file_list = [root_path + os.sep + line.strip() for line in output_list]
 


### PR DESCRIPTION
This changes the changed file detection to compare `HEAD` against the merge base of `HEAD` and `main`, rather than comparing `HEAD` against `main`.