### PR TITLE
Fix cpplint sre_compile deprecation warning

### DIFF
--- a/wpiformat/wpiformat/cpplint.py
+++ b/wpiformat/wpiformat/cpplint.py
@@ -49,9 +49,13 @@ import itertools
 import math  # for log
 import os
 import regex
-import sre_compile
 import string
 import sys
+
+try:
+    import re._compiler as sre_compile
+except ImportError:  # Python < 3.11
+    import sre_compile
 
 # if empty, use defaults
 _header_regex = regex.compile("a^")


### PR DESCRIPTION
sre_compile is an implementation detail of the re module that moved in Python 3.11.