### PR TITLE
Upgrade to clang-format and clang-tidy 18.1.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,12 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-11, windows-2022, ubuntu-22.04]
-        python-version: ['3.8', '3.9', '3.10']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        exclude:
+          - os: macos-11
+            python-version: '3.8'
+          - os: macos-11
+            python-version: '3.9'
     name: Test - ${{ matrix.os }}, ${{ matrix.python-version }}
     runs-on: ${{ matrix.os }}
     steps:

--- a/wpiformat/pyproject.toml
+++ b/wpiformat/pyproject.toml
@@ -4,11 +4,11 @@ description = "Linters and formatters for ensuring WPILib's source code conforms
 dynamic = [ "version" ]
 readme = "README.rst"
 dependencies = [
-  "regex==2023.10.3",
   "black==24.2.0",
-  "clang-format==17.0.5",
-  "clang-tidy==17.0.1",
-  "gersemi==0.11.0"
+  "clang-format==18.1.1",
+  "clang-tidy==18.1.1",
+  "gersemi==0.11.0",
+  "regex==2023.10.3"
 ]
 classifiers = [
   "Development Status :: 5 - Production/Stable",
@@ -35,9 +35,9 @@ wpiformat = "wpiformat:main"
 
 [build-system]
 requires = [
-  "clang-format==16.0.4",
-  "clang-tidy==15.0.2.1",
-  "regex==2022.9.13",
+  "clang-format==18.1.1",
+  "clang-tidy==18.1.1",
+  "regex==2023.10.3",
   "setuptools>=61.0",
   "setuptools-git-versioning"
 ]


### PR DESCRIPTION
Python 3.11 and 3.12 were added to CI, and Python 3.8 was dropped from CI because we have a limited amount of macOS runners. wpiformat can still run on Python 3.8 though.