### PR TITLE
wpiformat.task: Upgrade to Python 3 syntax

### DIFF
--- a/wpiformat/wpiformat/task.py
+++ b/wpiformat/wpiformat/task.py
@@ -9,9 +9,7 @@ from abc import *
 import os
 
 
-class Task:
-    __metaclass__ = ABCMeta
-
+class Task(metaclass=ABCMeta):
     @staticmethod
     def get_linesep(lines):
         """Returns string containing autodetected line separator for file.


### PR DESCRIPTION
`__metaclass__` does nothing in Python 3.