### PR TITLE
Fix cidentlist handling of single quotes in numeric literals

### DIFF
--- a/wpiformat/wpiformat/test/test_cidentlist.py
+++ b/wpiformat/wpiformat/test/test_cidentlist.py
@@ -494,4 +494,12 @@ def test_cidentlist():
         True,
     )
 
+    # Ensure single quotes in numeric literals are ignored
+    test.add_input("./Test.cpp", "void func() { int x = 1'000; }")
+    test.add_latest_input_as_output(True)
+
+    # Ensure single quotes after numeric literals are not ignored
+    test.add_input("./Test.cpp", "void func() { std::cout << 1 << '0'; }")
+    test.add_latest_input_as_output(True)
+
     test.run(OutputType.FILE)


### PR DESCRIPTION
Previously, `cidentlist.py` would assume that single quotes (outside of comments and strings) were only used to indicate character literals, but as of C++ 14, single quotes can also appear between digits in integer and decimal literals (as a readability aid).