### PR TITLE
Update CI Python versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,10 +8,8 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-14, windows-2022, ubuntu-22.04]
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
         exclude:
-          - os: macos-14
-            python-version: '3.8'
           - os: macos-14
             python-version: '3.9'
     name: Test - ${{ matrix.os }}, ${{ matrix.python-version }}
@@ -128,7 +126,7 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.10'
+          python-version: '3.13'
 
       - name: Install Python dependencies
         run: pip install build

--- a/wpiformat/pyproject.toml
+++ b/wpiformat/pyproject.toml
@@ -9,7 +9,7 @@ dependencies = [
   "clang-format==18.1.1",
   "clang-tidy==18.1.1",
   "gersemi==0.11.0",
-  "regex==2023.10.3"
+  "regex==2024.9.11"
 ]
 classifiers = [
   "Development Status :: 5 - Production/Stable",
@@ -38,7 +38,7 @@ wpiformat = "wpiformat:main"
 requires = [
   "clang-format==18.1.1",
   "clang-tidy==18.1.1",
-  "regex==2023.10.3",
+  "regex==2024.9.11",
   "setuptools>=61.0",
   "setuptools-git-versioning"
 ]


### PR DESCRIPTION
Python 3.8 is EOL, and Python 3.13 was recently released.