### PR TITLE
Fix cidentlist handling of single quotes in hex literals

### DIFF
--- a/wpiformat/wpiformat/cidentlist.py
+++ b/wpiformat/wpiformat/cidentlist.py
@@ -125,10 +125,11 @@ class CIdentList(PipelineTask):
             elif token == "\\'":
                 continue
             elif token == "'":
-                if not in_string and not (
-                    not in_char and self.is_quote_in_number(lines, match.start())
-                ):
-                    in_char = not in_char
+                if in_string:
+                    continue
+                if not in_char and self.is_quote_in_number(lines, match.start()):
+                    continue
+                in_char = not in_char
             elif in_string or in_char:
                 # Tokens processed after this branch are ignored if they are in
                 # double or single quotes

--- a/wpiformat/wpiformat/test/test_cidentlist.py
+++ b/wpiformat/wpiformat/test/test_cidentlist.py
@@ -499,8 +499,16 @@ def test_cidentlist():
     test.add_input("./Test.cpp", "void func() { int x = 1'000; }")
     test.add_latest_input_as_output(True)
 
+    # Ensure single quotes in hexadecimal literals are ignored
+    test.add_input("./Test.cpp", "void func() { int x = 0xffff'ffff; }")
+    test.add_latest_input_as_output(True)
+
     # Ensure single quotes after numeric literals are not ignored
     test.add_input("./Test.cpp", "void func() { std::cout << 1 << '0'; }")
+    test.add_latest_input_as_output(True)
+
+    # Ensure single quotes after hexadecimal characters are not ignored
+    test.add_input("./Test.cpp", "void func() { std::cout << 1 << 'a'; }")
     test.add_latest_input_as_output(True)
 
     test.run(OutputType.FILE)


### PR DESCRIPTION
Fixes #299.

Also removes the digit regex and instead directly checks the character (if any) before the single quote. This should work as long as the input is syntactically valid, since `0'` or `a'` should only be syntactically valid inside a numeric literal.

Also, I'm not sure whether applying [De Morgan's Laws](https://en.wikipedia.org/wiki/De_Morgan%27s_laws) to the condition in the `token == "'"` branch would help or hurt readability.