### PR TITLE
Fix README link to use .md instead of .rst

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Style configuration files for IDEs are in the [ide](ide) folder. The style guide
 
 ## Setup
 
-See the `wpiformat` Python package [README](wpiformat/README.rst).
+See the `wpiformat` Python package [README](wpiformat/README.md).
 
 ## Contributing to Style Guide
 


### PR DESCRIPTION
Change `styleguide/README.md` README link to use `wpiformat/README.md` instead of `wpiformat/README.rst`
`wpiformat/README.rst` was replaced in #304 