### PR TITLE
Allow empty files in EOF newline task

### DIFF
--- a/wpiformat/test/test_eofnewline.py
+++ b/wpiformat/test/test_eofnewline.py
@@ -24,7 +24,7 @@ def test_eofnewline():
 
     # Empty file
     test.add_input("./Test.h", "")
-    test.add_output("\n", True)
+    test.add_output("", True)
 
     test_output = file_appendix + os.linesep
 

--- a/wpiformat/wpiformat/eofnewline.py
+++ b/wpiformat/wpiformat/eofnewline.py
@@ -1,8 +1,12 @@
-"""This task ensures that the file has exactly one EOF newline."""
+"""This task ensures that the file has zero EOF newlines if it's empty or one EOF newline."""
 
 from wpiformat.task import PipelineTask
 
 
 class EofNewline(PipelineTask):
     def run_pipeline(self, config_file, name, lines):
-        return lines.rstrip() + super().get_linesep(lines), True
+        lines = lines.rstrip()
+        if lines:
+            return lines + super().get_linesep(lines), True
+        else:
+            return lines, True


### PR DESCRIPTION
Per
https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap03.html#tag_03_403, a file is allowed to have zero or more lines where a line is terminated by a newline character.