### PR TITLE
Filter "Processing file" lines out of clang-tidy output

### DIFF
--- a/wpiformat/wpiformat/clangtidy.py
+++ b/wpiformat/wpiformat/clangtidy.py
@@ -60,6 +60,9 @@ class ClangTidy(StandaloneTask):
         # Filter out "Error while processing" lines
         lines = [l for l in lines if "Error while processing" not in l]
 
+        # Filter out "Processing file" lines
+        lines = [l for l in lines if "Processing file" not in l]
+
         # Ignore include file not found errors
         filtered_lines = []
         iterlines = iter(lines)


### PR DESCRIPTION
```
== clang-tidy /home/tav/frc/wpilib/allwpilib/benchmark/src/main/native/cpp/Main.cpp ==
[1/1] (1/2) Processing file /home/tav/frc/wpilib/allwpilib/benchmark/src/main/native/cpp/Main.cpp.
[1/1] (2/2) Processing file /home/tav/frc/wpilib/allwpilib/benchmark/src/main/native/cpp/Main.cpp.
```