### PR TITLE
Set git name and email in licenseupdate tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,8 +62,6 @@ jobs:
 
     - name: Run unit tests
       run: |
-        git config --global user.email "you@example.com"
-        git config --global user.name "Your Name"
         cd wpiformat
         pytest
 
@@ -105,6 +103,8 @@ jobs:
         rm -rf branch-test
         git config --global init.defaultBranch develop
         mkdir branch-test && cd branch-test && git init
+        git config user.email "you@example.com"
+        git config user.name "Your Name"
         touch .wpiformat && git add .wpiformat && git commit -q -m "Initial commit"
         if wpiformat; then
           exit 1
@@ -117,6 +117,8 @@ jobs:
         rm -rf branch-test
         git config --global init.defaultBranch develop
         mkdir branch-test && cd branch-test && git init
+        git config user.email "you@example.com"
+        git config user.name "Your Name"
         touch .wpiformat && git add .wpiformat && git commit -q -m "Initial commit"
         wpiformat -default-branch develop
 
@@ -127,6 +129,8 @@ jobs:
         rm -rf branch-test
         git config --global init.defaultBranch main
         mkdir branch-test && cd branch-test && git init
+        git config user.email "you@example.com"
+        git config user.name "Your Name"
         touch .wpiformat && git add .wpiformat && git commit -q -m "Initial commit"
         wpiformat
 
@@ -137,6 +141,8 @@ jobs:
         rm -rf branch-test
         git config --global init.defaultBranch master
         mkdir branch-test && cd branch-test && git init
+        git config user.email "you@example.com"
+        git config user.name "Your Name"
         touch .wpiformat && git add .wpiformat && git commit -q -m "Initial commit"
         wpiformat
 

--- a/wpiformat/test/test_licenseupdate.py
+++ b/wpiformat/test/test_licenseupdate.py
@@ -9,9 +9,16 @@ from wpiformat.licenseupdate import LicenseUpdate
 from .test_tasktest import *
 
 
+def init_repo():
+    subprocess.run(["git", "init", "-q"])
+    subprocess.run(["git", "config", "user.email", "you@example.com"])
+    subprocess.run(["git", "config", "user.name", "Your Name"])
+
+
 def test_licenseupdate():
     with OpenTemporaryDirectory():
-        subprocess.run(["git", "init", "-q"])
+        init_repo()
+
         Path(".wpiformat").write_text(r"""licenseUpdateExclude {
   Excluded\.hpp$
 }
@@ -232,12 +239,12 @@ blah
 
     # Create git repo to test license years for commits
     with OpenTemporaryDirectory():
+        init_repo()
+
         last_year_cpp = Path("last-year.cpp").resolve()
         next_year_cpp = Path("next-year.cpp").resolve()
         no_year_cpp = Path("no-year.cpp").resolve()
         this_year_cpp = Path("this-year.cpp").resolve()
-
-        subprocess.run(["git", "init", "-q"])
 
         # Add base files
         Path(".wpiformat-license").write_text("// Copyright (c) {year}")
@@ -323,7 +330,7 @@ change
 
     # Create git repo to test filename expansion
     with OpenTemporaryDirectory():
-        subprocess.run(["git", "init", "-q"])
+        init_repo()
 
         # Add base files
         Path(".wpiformat-license").write_text("""// Copyright (c) {year}


### PR DESCRIPTION
This fixes the following error when tests are run by a user without a configured committer identity (e.g., Linux packaging):
```
E               subprocess.CalledProcessError: Command '['git', 'log', '-n', '1', '--format=%ci', '--', PosixPath('/tmp/tmpirmw8i6e/Test.hpp')]' returned non-zero exit status 128.

/usr/lib/python3.14/subprocess.py:578: CalledProcessError
----------------------------------------------- Captured stderr call -----------------------------------------------
Committer identity unknown

*** Please tell me who you are.

Run

  git config --global user.email "you@example.com"
  git config --global user.name "Your Name"

to set your account's default identity.
Omit --global to set the identity only in this repository.

fatal: unable to auto-detect email address (got 'tav@myriad.(none)')
fatal: your current branch 'master' does not have any commits yet
============================================= short test summary info ==============================================
FAILED test/test_licenseupdate.py::test_licenseupdate - subprocess.CalledProcessError: Command '['git', 'log', '-n', '1', '--format=%ci', '--', PosixPath('/tmp/tmpirmw...
=========================================== 1 failed, 11 passed in 0.13s ===========================================
```