### PR TITLE
Add config regex to disable python's isort linter

### DIFF
--- a/wpiformat/wpiformat/config.py
+++ b/wpiformat/wpiformat/config.py
@@ -21,6 +21,7 @@ class Config:
         self.__cpp_src_include_regex = self.regex("cppSrcFileInclude")
         self.__generated_exclude_regex = self.regex("generatedFileExclude")
         self.__modifiable_exclude_regex = self.regex("modifiableFileExclude")
+        self.__isort_exclude_regex = self.regex("pythonIsortFileExclude")
 
     @staticmethod
     def read_file(directory: Path, filename: Path) -> tuple[Path, list[str]]:
@@ -175,6 +176,15 @@ class Config:
         filename -- filename
         """
         return self.__modifiable_exclude_regex.search(filename.as_posix()) is not None
+
+    def is_excluded_isort_file(self, filename: Path) -> bool:
+        """
+        Returns True if the file is in the isort exclude list.
+
+        Keyword Arguments:
+        filename -- filename
+        """
+        return self.__isort_exclude_regex.search(filename.as_posix()) is not None
 
     def __parse_config_file(
         self, directory: Path, filename: Path

--- a/wpiformat/wpiformat/pyformat.py
+++ b/wpiformat/wpiformat/pyformat.py
@@ -44,11 +44,20 @@ class PyFormat(BatchTask):
             print("error: black not found in PATH. Is it installed?", file=sys.stderr)
             return False
 
-        try:
-            args = [sys.executable, "-m", "isort", "--profile", "black", "-q"]
-            subprocess.run(args + filenames)
-        except FileNotFoundError:
-            print("error: isort not found in PATH. Is it installed?", file=sys.stderr)
-            return False
+        # Apply user defined filter to files before calling isort
+        isort_filenames = []
+        for filename in filenames:
+            if not config_file.is_excluded_isort_file(filename):
+                isort_filenames.append(filename)
+
+        if isort_filenames:
+            try:
+                args = [sys.executable, "-m", "isort", "--profile", "black", "-q"]
+                subprocess.run(args + isort_filenames)
+            except FileNotFoundError:
+                print(
+                    "error: isort not found in PATH. Is it installed?", file=sys.stderr
+                )
+                return False
 
         return True


### PR DESCRIPTION
Compared to black and autoflake, the isort linter can be aggressive and seemingly arbitrary, especially In the case of a library like robot where import order matters.

This adds the ability to set a regex that will exclude files from the isort process. See complaints in regards to robotpy
https://github.com/wpilibsuite/allwpilib/pull/8362#discussion_r3432898487
https://github.com/wpilibsuite/allwpilib/pull/8362#discussion_r3432905083