### PR TITLE
Remove 3 suffix from python3

### DIFF
--- a/wpiformat/wpiformat/__init__.py
+++ b/wpiformat/wpiformat/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 
 import argparse
 import math

--- a/wpiformat/wpiformat/__main__.py
+++ b/wpiformat/wpiformat/__main__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 
 import wpiformat
 


### PR DESCRIPTION
`python` used to refer to Python 2, but that's been EOL since 2020.